### PR TITLE
help handling non-latin encoding

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -292,11 +292,14 @@ class Instant_Articles_Post {
 			$DOMDocument = new DOMDocument( '1.0', get_option( 'blog_charset' ) );
 			
 			// DOMDocument isn’t handling encodings too well, so let’s help it a little
+			$xml_prefix = '';
 			if ( function_exists( 'mb_convert_encoding' ) ) {
 				$content = mb_convert_encoding( $content, 'HTML-ENTITIES', get_option( 'blog_charset' ) );
+			} else {
+				$xml_prefix = '<?xml encoding="'.get_option( 'blog_charset' ).'" ?>';
 			}
 			
-			$result = $DOMDocument->loadHTML( '<!doctype html><html><body>' . $content . '</body></html>' );
+			$result = $DOMDocument->loadHTML( $xml_prefix . '<!doctype html><html><body>' . $content . '</body></html>' );
 			libxml_clear_errors();
 			libxml_use_internal_errors( $libxml_previous_state );
 


### PR DESCRIPTION
This commit helps handling non-latin encoding even if `mb_convert_encoding` is unavailable. 
