### PR TITLE
make fetching of custom post types possible

### DIFF
--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -140,6 +140,15 @@ function instant_articles_query( $query ) {
 		$query->set( 'posts_per_page', 100 );
 		$query->set( 'posts_per_rss', 100 );
 
+		// Let users define their own feed post_type
+		if( defined( 'INSTANT_ARTICLES_POST_TYPE' ) && INSTANT_ARTICLES_POST_TYPE){
+			$instant_articles_post_type = @unserialize(INSTANT_ARTICLES_POST_TYPE);
+			if(!$instant_articles_post_type)
+				$instant_articles_post_type = INSTANT_ARTICLES_POST_TYPE;
+
+			$query->set( 'post_type', $instant_articles_post_type );
+		}
+
 		/**
 		 * If the constant INSTANT_ARTICLES_LIMIT_POSTS is set to true, we will limit the feed
 		 * to only include posts which are modified within the last 24 hours.
@@ -183,5 +192,3 @@ function instant_articles_query_where( $where, $query ) {
 
 }
 add_filter( 'posts_where' , 'instant_articles_query_where', 10, 2 );
-
-


### PR DESCRIPTION
added possibility for changing post_type of fetched posts for feeds (needed it for custom post types ;) )

```
//declaration in functions.php
add_action( 'init', 'set_instant_articles_constants', 9);
function set_instant_articles_constants(){
  define( 'INSTANT_ARTICLES_POST_TYPE', 'desired_post_type_1' );
  /* OR */
  define( 'INSTANT_ARTICLES_POST_TYPE', serialize( array('desired_post_type_1', 'desired_post_type_2' ) ) );
}
```