### PR TITLE
Use SDK engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+vendor
+composer.lock

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -1,5 +1,22 @@
 <?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
 
+use Facebook\InstantArticles\Elements\InstantArticle;
+use Facebook\InstantArticles\Elements\Header;
+use Facebook\InstantArticles\Elements\Time;
+use Facebook\InstantArticles\Elements\Ad;
+use Facebook\InstantArticles\Elements\Analytics;
+use Facebook\InstantArticles\Elements\Author;
+use Facebook\InstantArticles\Elements\Image;
+use Facebook\InstantArticles\Elements\Caption;
+use Facebook\InstantArticles\Elements\Footer;
+use Facebook\InstantArticles\Transformer\Transformer;
 /**
  * Class responsible for constructing our content and preparing it for rendering
  *
@@ -7,51 +24,73 @@
  */
 class Instant_Articles_Post {
 
-	/** @var int ID of the post */
-	protected $_ID = 0;
+	/**
+	 * The post
+	 *
+	 * @var $_post
+	 */
+	protected $_post = null;
 
-	/** @var string Cached version of the Instant Article body */
+	/**
+	 * The post cached content
+	 *
+	 * @var string $_content
+	 */
 	protected $_content = null;
 
 	/** @var string The post’s optional subtitle */
 	protected $_subtitle = null;
 
 	/**
+	 * Instant Article instance object
+	 *
+	 * @var InstantArticle Last built version of the Instant Article object
+	 */
+	protected $_instant_article = null;
+
+	/**
+	 * Instant Article Transformer instance object
+	 *
+	 * @var Transformer The Transformer object
+	 */
+	public $transformer = null;
+
+	/**
 	 * Setup data and build the content
 	 *
 	 * @since 0.1
-	 * @param int  $post_id  ID of the post
+	 * @param Instant_Article_Post $post ID of the post.
 	 */
-	function __construct( $post_id ) {
-		$this->_ID = $post_id;
+	public function __construct( $post ) {
+		$this->_post = $post;
 	}
 
 	/**
-	 * Get the ID for this post
+	 * Get the ID for this post.
 	 *
 	 * @since 0.1
-	 * @return int  The post ID
+	 * @return int The post ID.
 	 */
-	public function get_the_ID() {
+	public function get_the_id() {
 		return $this->_ID;
 	}
 
 	/**
-	 * Get the title for this post
+	 * Get the title for this post.
 	 *
 	 * @since 0.1
-	 * @return string The title
+	 * @return string The title.
 	 */
 	public function get_the_title() {
-		$title = get_the_title( $this->get_the_ID() );
+		$title = $this->_post->post_title;
 
 		/**
-		 * Filter the post title for use in instant articles
+		 * Filter the post title for use in instant articles.
 		 *
 		 * @since 0.1
 		 *
-		 * @param string                 $title                 The current post title.
-		 * @param Instant_Article_Post   $instant_article_post  The instant article post
+		 * @param string $title The current post title.
+		 * @param Instant_Article_Post $instant_article_post The instant article post.
 		 */
 		$title = apply_filters( 'instant_articles_title', $title, $this );
 
@@ -59,10 +98,10 @@ class Instant_Articles_Post {
 	}
 
 	/**
-	 * Get the title for this post
+	 * Get the title for this post.
 	 *
 	 * @since 0.1
-	 * @return string  The title
+	 * @return string The title.
 	 */
 	public function get_the_title_rss() {
 		$title = $this->get_the_title();
@@ -72,7 +111,7 @@ class Instant_Articles_Post {
 		 *
 		 * @since 0.1
 		 *
-		 * @param string  $title  The current post title.
+		 * @param string $title The current post title.
 		 */
 		$title = apply_filters( 'the_title_rss', $title );
 
@@ -86,7 +125,7 @@ class Instant_Articles_Post {
 	 * @return bool Whether the post has a subtitle or not
 	 */
 	public function has_subtitle() {
-		
+
 		$has_subtitle = false;
 
 		$subtitle = $this->get_the_subtitle();
@@ -129,30 +168,14 @@ class Instant_Articles_Post {
 	}
 
 	/**
-	 * Get the canonical URL for this post
-	 *
-	 * A little warning here: It is extremely important that this is the same canonical URL as is used on the web site.
-	 * This is the identificator Facebook use to connect the "read" web article with the instant article.
-	 * Do not add any querystring params or URL fragments it. Not any. Not even for tracking.
+	 * Get the excerpt for this post.
 	 *
 	 * @since 0.1
-	 * @return string  The canonical URL
-	 */
-	public function get_canonical_url() {
-		$url = get_permalink( $this->get_the_ID() );
-
-		return $url;
-	}
-
-	/**
-	 * Get the excerpt for this post
-	 *
-	 * @since 0.1
-	 * @return string  The excerpt
+	 * @return string  The excerpt.
 	 */
 	public function get_the_excerpt() {
 
-		$post = get_post( $this->get_the_ID() );
+		$post = get_post( $this->get_the_id() );
 
 		// This should ideally not happen, but it may do so if someone tampers with the query.
 		// Returning the same protected post excerpt as "usual" may help them identify what’s going on.
@@ -160,11 +183,11 @@ class Instant_Articles_Post {
 			return __( 'There is no excerpt because this is a protected post.' );
 		}
 
-		// Make sure no “read more” link is added
+		// Make sure no “read more” link is added.
 		add_filter( 'excerpt_more', '__return_empty_string', 999 );
 
 		/**
-		 * Apply the default WP Filters for the post excerpt
+		 * Apply the default WP Filters for the post excerpt.
 		 *
 		 * @since 0.1
 		 *
@@ -173,12 +196,12 @@ class Instant_Articles_Post {
 		$excerpt = apply_filters( 'get_the_excerpt', $post->post_excerpt );
 
 		/**
-		 * Filter the post excerpt for instant articles
+		 * Filter the post excerpt for instant articles.
 		 *
 		 * @since 0.1
 		 *
-		 * @param string                 $excerpt               The current post excerpt.
-		 * @param Instant_Article_Post   $instant_article_post  The instant article post
+		 * @param string $excerpt The current post excerpt.
+		 * @param Instant_Article_Post $instant_article_post The instant article post.
 		 */
 		$excerpt = apply_filters( 'instant_articles_excerpt', $excerpt, $this );
 
@@ -208,6 +231,31 @@ class Instant_Articles_Post {
 	}
 
 	/**
+	 * Get the canonical URL for this post
+	 *
+	 * A little warning here: It is extremely important that this is the same canonical URL as is used on the web site.
+	 * This is the identificator Facebook use to connect the "read" web article with the instant article.
+	 * Do not add any querystring params or URL fragments it. Not any. Not even for tracking.
+	 *
+	 * @since 0.1
+	 * @return string  The canonical URL
+	 */
+	public function get_canonical_url() {
+		// If post is draft, clone it to get the eventual permalink,
+		// see http://wordpress.stackexchange.com/a/42988.
+		if ( in_array( $this->_post->post_status, array( 'draft', 'pending', 'auto-draft' ), true ) ) {
+		    $post_clone = clone $this->_post;
+		    $post_clone->post_status = 'published';
+		    $post_clone->post_name = sanitize_title( $post_clone->post_name ? $post_clone->post_name : $post_clone->post_title, $post_clone->ID );
+		    $url = get_permalink( $post_clone );
+		} else {
+		    $url = get_permalink( $this->_post );
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Get the article body for this post
 	 *
 	 * @since 0.1
@@ -231,34 +279,38 @@ class Instant_Articles_Post {
 	 */
 	protected function _get_the_content() {
 
-		// Try to get the content from a transient, but only if the cached version have the same modtime
-		$cache_mod_time = get_transient( 'instantarticles_mod_' . $this->get_the_ID() );
-		if ( $cache_mod_time == get_post_modified_time( 'Y-m-d H:i:s', true, $this->get_the_ID() ) ) {
-			$content = get_transient( 'instantarticles_content_' . $this->get_the_ID() );
-			if ( $content !== false && strlen( $content ) ) {
+		// Try to get the content from a transient, but only if the cached version have the same modtime.
+		$cache_mod_time = get_transient( 'instantarticles_mod_' . $this->_post->ID );
+		if ( get_post_modified_time( 'Y-m-d H:i:s', true, $this->_post->ID ) === $cache_mod_time ) {
+			$content = get_transient( 'instantarticles_content_' . $this->_post->ID );
+			if ( false !== $content && strlen( $content ) ) {
 				return $content;
 			}
 		}
 
 		global $post, $more;
 
-		// force $more
+		if ( ! $post ) {
+			return '';
+		}
+
+		// Force $more.
 		$orig_more = $more;
 		$more = 1;
 
-		// If we’re not it the loop or otherwise properly setup
+		// If we’re not it the loop or otherwise properly setup.
 		$reset_postdata = false;
-		if ( $this->get_the_ID() !== $post->ID ) {
-			$post = get_post( $this->get_the_ID() );
+		if ( $this->_post->ID !== $post->ID ) {
+			$post = get_post( $this->_post->ID );
 			setup_postdata( $post );
 			$reset_postdata = true;
 		}
 
-		// Now get the content
-		$content = get_the_content();
+		// Now get the content.
+		$content = $this->_post->post_content;
 
 		/**
-		 * Apply the default filter 'the_content' for the post content
+		 * Apply the default filter 'the_content' for the post content.
 		 *
 		 * @since 0.1
 		 * @param string  $content  The current post content.
@@ -275,133 +327,37 @@ class Instant_Articles_Post {
 		$content = wpautop( $content );
 
 		/**
-		 * Filter the post content for Instant Articles
+		 * Filter the post content for Instant Articles.
 		 *
 		 * @since 0.1
 		 * @param string  $content  The post content.
 		 */
 		$content = apply_filters( 'instant_articles_content', $content );
 
-
-		if ( class_exists( 'DOMDocument' ) && has_action( 'instant_articles_register_dom_transformation_filters' ) ) {
-
-			/* If we have filters that wants to work on the DOM, we generate one instance of DOMDocument
-			   they can all work on, instead of having to handle the conversion themselves. */
-
-			$libxml_previous_state = libxml_use_internal_errors( true );
-			$DOMDocument = new DOMDocument( '1.0', get_option( 'blog_charset' ) );
-			
-			// DOMDocument isn’t handling encodings too well, so let’s help it a little
-			if ( function_exists( 'mb_convert_encoding' ) ) {
-				$content = mb_convert_encoding( $content, 'HTML-ENTITIES', get_option( 'blog_charset' ) );
-			}
-			
-			$result = $DOMDocument->loadHTML( '<!doctype html><html><body>' . $content . '</body></html>' );
-			libxml_clear_errors();
-			libxml_use_internal_errors( $libxml_previous_state );
-
-			if ( $result ) {
-
-				// Register the DOM transformation filters if not done yet
-				if ( ! did_action( 'instant_articles_register_dom_transformation_filters' ) ) {
-					do_action( 'instant_articles_register_dom_transformation_filters' );
-				}
-				Instant_Articles_DOM_Transform_Filter_Runner::run( $DOMDocument, $this->get_the_ID() );
-
-
-				$body = $DOMDocument->getElementsByTagName( 'body' )->item( 0 );
-
-				$filtered_content = '';
-				foreach ( $body->childNodes as $node ) {
-					if ( method_exists( $DOMDocument, 'saveHTML' ) ) { // Requires PHP 5.3.6
-						$filtered_content .= $DOMDocument->saveHTML( $node );
-					} else {
-						$temp_content = $DOMDocument->saveXML( $node );
-						$iframe_pattern = "#<iframe([^>]+)/>#is"; // self-closing iframe element
-						$temp_content = preg_replace( $iframe_pattern, "<iframe$1></iframe>", $temp_content );
-						$filtered_content .= $temp_content;
-					}
-				}
-
-				$content = $filtered_content;
-				unset( $filtered_content );
-
-			}
-
-		}
-
-		// Cache the content
-		set_transient( 'instantarticles_mod_' . $this->get_the_ID(), get_post_modified_time( 'Y-m-d H:i:s', true, $this->get_the_ID() ), WEEK_IN_SECONDS );
-		set_transient( 'instantarticles_content_' . $this->get_the_ID(), $content, WEEK_IN_SECONDS );
+		// Cache the content.
+		set_transient( 'instantarticles_mod_' . $this->_post->ID, get_post_modified_time( 'Y-m-d H:i:s', true, $this->_post->ID ), WEEK_IN_SECONDS );
+		set_transient( 'instantarticles_content_' . $this->_post->ID, $content, WEEK_IN_SECONDS );
 
 		return $content;
 	}
 
 	/**
-	 * Get the published date for this post
+	 * Get the published date for this post (ISO 8601).
 	 *
 	 * @since 0.1
-	 * @return string  The published date
-	 */
-	public function get_the_pubdate() {
-
-		$date = get_post_time( get_option( 'date_format' ), true, $this->get_the_ID() );
-
-		/**
-		 * Filter the post date for instant articles
-		 *
-		 * @since 0.1
-		 *
-		 * @param string                 $date               The current post date.
-		 * @param Instant_Article_Post   $instant_article_post  The instant article post
-		 */
-		$date = apply_filters( 'instant_articles_date', $date, $this );
-
-		return $date;
-
-	}
-
-	/**
-	 * Get the modified date for this post
-	 *
-	 * @since 0.1
-	 * @return string  The modified date
-	 */
-	public function get_the_moddate() {
-
-		$modified_date = get_post_modified_time( get_option('date_format'), true, $this->get_the_ID() );
-
-		/**
-		 * Filter the post modified date for instant articles
-		 *
-		 * @since 0.1
-		 *
-		 * @param string                 $modified_date         The current post modified date.
-		 * @param Instant_Article_Post   $instant_article_post  The instant article post
-		 */
-		$modified_date = apply_filters( 'instant_articles_modified_date', $modified_date, $this );
-
-		return $modified_date;
-
-	}
-
-	/**
-	 * Get the published date for this post (ISO 8601)
-	 *
-	 * @since 0.1
-	 * @return string  The published date formatted suitable for use in the RSS feed and the html time elements (ISO 8601)
+	 * @return string  The published date formatted suitable for use in the RSS feed and the html time elements (ISO 8601).
 	 */
 	public function get_the_pubdate_iso() {
 
-		$published_date = mysql2date( 'c', get_post_time( 'Y-m-d H:i:s', true, $this->get_the_ID() ), false );
+		$published_date = mysql2date( 'c', get_post_time( 'Y-m-d H:i:s', true, $this->_post->ID ), false );
 
 		/**
-		 * Filter the post published date (ISO 8601)
+		 * Filter the post published date (ISO 8601).
 		 *
 		 * @since 0.1
 		 *
 		 * @param string                 $published_date        The current post published date.
-		 * @param Instant_Article_Post   $instant_article_post  The instant article post
+		 * @param Instant_Article_Post   $instant_article_post  The instant article post.
 		 */
 		$published_date = apply_filters( 'instant_articles_published_date_iso', $published_date, $this );
 
@@ -410,22 +366,22 @@ class Instant_Articles_Post {
 	}
 
 	/**
-	 * Get the modified date for this post (ISO 8601)
+	 * Get the modified date for this post (ISO 8601).
 	 *
 	 * @since 0.1
-	 * @return string  The modified date formatted suitable for use in the RSS feed and the html time elements (ISO 8601)
+	 * @return string  The modified date formatted suitable for use in the RSS feed and the html time elements (ISO 8601).
 	 */
 	public function get_the_moddate_iso() {
 
-		$modified_date = mysql2date( 'c', get_post_modified_time( 'Y-m-d H:i:s', true, $this->get_the_ID() ), false );
+		$modified_date = mysql2date( 'c', get_post_modified_time( 'Y-m-d H:i:s', true, $this->_post->ID ), false );
 
 		/**
-		 * Filter the post modified date (ISO 8601)
+		 * Filter the post modified date (ISO 8601).
 		 *
 		 * @since 0.1
 		 *
 		 * @param string                 $modified_date         The current post modified date.
-		 * @param Instant_Article_Post   $instant_article_post  The instant article post
+		 * @param Instant_Article_Post   $instant_article_post  The instant article post.
 		 */
 		$modified_date = apply_filters( 'instant_articles_modified_date_iso', $modified_date, $this );
 
@@ -433,56 +389,54 @@ class Instant_Articles_Post {
 
 	}
 	/**
-	 * Get the author(s)
+	 * Get the author(s).
 	 *
 	 * @since 0.1
-	 * @return array  $authors  The post author(s)
+	 * @return array  $authors  The post author(s).
 	 */
 	public function get_the_authors() {
 
 		$authors = array();
 
-		$post = get_post( $this->get_the_ID() );
+		$wp_user = get_userdata( $this->_post->author );
 
-		$WP_User = get_userdata( $post->post_author );
-
-		if ( is_a( $WP_User, 'WP_User' ) ) {
+		if ( is_a( $wp_user, 'WP_User' ) ) {
 			$author = new stdClass;
-			$author->ID            = $WP_User->ID;
-			$author->display_name  = $WP_User->data->display_name;
-			$author->first_name    = $WP_User->first_name;
-			$author->last_name     = $WP_User->last_name;
-			$author->user_login    = $WP_User->data->user_login;
-			$author->user_nicename = $WP_User->data->user_nicename;
-			$author->user_email    = $WP_User->data->user_email;
-			$author->user_url      = $WP_User->data->user_url;
-			$author->bio           = $WP_User->description;
+			$author->ID            = $wp_user->ID;
+			$author->display_name  = $wp_user->data->display_name;
+			$author->first_name    = $wp_user->first_name;
+			$author->last_name     = $wp_user->last_name;
+			$author->user_login    = $wp_user->data->user_login;
+			$author->user_nicename = $wp_user->data->user_nicename;
+			$author->user_email    = $wp_user->data->user_email;
+			$author->user_url      = $wp_user->data->user_url;
+			$author->bio           = $wp_user->description;
 
 			$authors[] = $author;
 		}
 
 		/**
-		 * Filter the post author(s)
+		 * Filter the post author(s).
 		 *
 		 * @since 0.1
 		 *
 		 * @param array  $authors  The current post author(s).
-		 * @param int    $post_id  The instant article post
+		 * @param int    $post_id  The instant article post.
 		 */
-		$authors = apply_filters( 'instant_articles_authors', $authors, $this->get_the_ID() );
+		$authors = apply_filters( 'instant_articles_authors', $authors, $this->_post->ID );
 
 		return $authors;
 	}
 
 	/**
-	 * Get featured image for cover
+	 * Get featured image for cover.
 	 *
 	 * @since 0.1
 	 * @return array {
 	 *     Array containing image source and caption.
 	 *
-	 *     @type string $src Image URL
-	 *     @type string $caption Image caption
+	 *     @type string $src Image URL.
+	 *     @type string $caption Image caption.
 	 * }
 	 */
 	public function get_the_featured_image() {
@@ -491,11 +445,11 @@ class Instant_Articles_Post {
 			'src' => '',
 			'caption' => '',
 		);
-		if ( has_post_thumbnail( $this->get_the_ID() ) ) {
+		if ( has_post_thumbnail( $this->_post->ID ) ) {
 
-			$image_array = wp_get_attachment_image_src( get_post_thumbnail_id( $this->get_the_ID() ), 'full' );
-			$attachment_id   = get_post_thumbnail_id( $this->get_the_ID() );
-			
+			$image_array = wp_get_attachment_image_src( get_post_thumbnail_id( $this->_post->ID ), 'full' );
+			$attachment_id   = get_post_thumbnail_id( $this->_post->ID );
+
 			if ( is_array( $image_array ) ) {
 				$image_data['src'] = $image_array[0];
 				$attachment_post = get_post( $attachment_id );
@@ -506,26 +460,26 @@ class Instant_Articles_Post {
 		}
 
 		/**
-		 * Filter the featured image
+		 * Filter the featured image.
 		 *
 		 * @since 0.1
 		 * @param array $image_data {
 		 *     Array containg image source and caption.
 		 *
-		 *     @type string $src Image URL
-		 *     @type string $caption Image caption
+		 *     @type string $src Image URL.
+		 *     @type string $caption Image caption.
 		 * }
-		 * @param int $post_id The post ID
+		 * @param int $post_id The post ID.
 		 */
-		$image_data = apply_filters( 'instant_articles_featured_image', $image_data, $this->get_the_ID() );
+		$image_data = apply_filters( 'instant_articles_featured_image', $image_data, $this->_post->ID );
 		return $image_data;
 	}
 
 	/**
-	 * Get the cover media
+	 * Get the cover media.
 	 *
 	 * @since 0.1
-	 * @return array  
+	 * @return array
 	 */
 	public function get_cover_media() {
 
@@ -535,13 +489,13 @@ class Instant_Articles_Post {
 		// If someone else is handling this, let them. Otherwise fall back to us trying to use the featured image.
 		if ( has_filter( 'instant_articles_cover_media' ) ) {
 			/**
-			 * Filter the cover media
+			 * Filter the cover media.
 			 *
 			 * @since 0.1
-			 * @param stdClass  $cover_media  The cover media object
-			 * @param int       $post_id      The current post ID
+			 * @param stdClass  $cover_media  The cover media object.
+			 * @param int       $post_id      The current post ID.
 			 */
-			$cover_media = apply_filters( 'instant_articles_cover_media', $cover_media, $this->get_the_ID() );
+			$cover_media = apply_filters( 'instant_articles_cover_media', $cover_media, $this->_post->ID );
 		} else {
 			$featured_image_data = $this->get_the_featured_image();
 			if ( isset( $featured_image_data['src'] ) && strlen( $featured_image_data['src'] ) ) {
@@ -555,10 +509,10 @@ class Instant_Articles_Post {
 	}
 
 	/**
-	 * Get kicker text
+	 * Get kicker text.
 	 *
 	 * @since 0.1
-	 * @return string  
+	 * @return string
 	 */
 	public function get_the_kicker() {
 
@@ -573,145 +527,334 @@ class Instant_Articles_Post {
 		}
 
 		/**
-		 * Filter the kicker text
+		 * Filter the kicker text.
 		 *
 		 * @since 0.1
 		 *
 		 * @param string  $category  The first category returned from get_the_category().
-		 * @param int     $post_id   The post ID
+		 * @param int     $post_id   The post ID.
 		 */
-		$category_kicker = apply_filters('instant_articles_cover_kicker', $category,  $this->get_the_ID() );
+		$category_kicker = apply_filters( 'instant_articles_cover_kicker', $category,  $this->_post->ID );
 
 		return $category_kicker ? $category_kicker : '';
 	}
 
 	/**
-	 * Get newsfeed cover type, image or video
+	 * Get newsfeed cover type, image or video.
 	 *
 	 * @since 0.1
-	 * @return string  
+	 * @return string
 	 */
 	public function get_newsfeed_cover() {
 
 		$type = 'image';
 
 		/**
-		 * Filter the cover type property 
+		 * Filter the cover type property.
 		 *
 		 * @since 0.1
 		 *
 		 * @param string  $type     Set to 'video' for video cover. Featured image (image) is default.
-		 * @param int     $post_id  The post ID
+		 * @param int     $post_id  The post ID.
 		 */
-		$type = apply_filters( 'instant_articles_cover_type', $type,  $this->get_the_ID() );
+		$type = apply_filters( 'instant_articles_cover_type', $type,  $this->_post->ID );
 
 		return $type;
 	}
 
-	/**
-	 * Get credits for footer. 
-	 *
-	 * @since 0.1
-	 * @return string  
-	 */
-	public function get_the_footer_credits() {
-
-		/**
-		* Filter credits 
-		*
-		* @since 0.1
-		*
-		* @param string  No credits set by default.
-		* @param int     The post ID
-		*/
-		$footer_credits = apply_filters( 'instant_articles_footer_credits', '', $this->get_the_ID() );
-		return $footer_credits; 
-	}
-
-
-	/**
-	 * Get copyright for footer
-	 *
-	 * @since 0.1
-	 * @return string  
-	 */
-	public function get_the_footer_copyright() {
-
-		/**
-		* Filter copyright
-		*
-		* @since 0.1
-		*
-		* @param string  No copyright set by default.
-		* @param int  	 The post ID
-		*/
-		$footer_copyright = apply_filters( 'instant_articles_footer_copyright', '', $this->get_the_ID() );
-		return $footer_copyright; 
-	}
 
 	/**
 	 * Render post
 	 *
 	 * @since 0.1
+	 * @return InstantArticle
 	 */
-	function render() {
+	public function to_instant_article() {
 
 		/**
-	     * Fires before the instant article is rendered
+	     * Fires before the instant article is rendered.
 	     *
 	     * @since 0.1
-	     * @param Instant_Article_Post  $instant_article_post  The instant article post
+	     * @param Instant_Article_Post  $instant_article_post  The instant article post.
 	     */
-		do_action( 'instant_articles_before_render_post', $this );
-		
-		$default_template = dirname( __FILE__ ) . '/template.php';
+		do_action( 'instant_articles_before_transform_post', $this );
 
-		/**
-	     * Filter the path to the template to use to render the instant article
-	     *
-	     * @since 0.1
-	     * @param string                    $template               Path to the current (default) template.
-	     * @param Instant_Article_Post      $instant_article_post   The instant article post
-	     */
-		$template = apply_filters( 'instant_articles_render_post_template', $default_template, $this );
-		
-		// Make sure the template exists. Devs do the darndest things.
-		// Note on validate_file(): Return value of 0 means nothing is wrong, greater than 0 means something was wrong.
-		if ( ! file_exists( $template ) || validate_file( $template ) ) {
-			$template = $default_template;
+		// Get time zone configured in WordPress. Default to UTC if no time zone configured.
+		$date_time_zone = get_option( 'timezone_string' ) ? new DateTimeZone( get_option( 'timezone_string' ) ) : new DateTimeZone( 'UTC' );
+
+		$header =
+			Header::create()
+				->withPublishTime(
+					Time::create( Time::PUBLISHED )->withDatetime( new DateTime( $this->_post->post_date, $date_time_zone ) )
+				)
+				->withModifyTime(
+					Time::create( Time::MODIFIED )->withDatetime( new DateTime( $this->_post->post_modified, $date_time_zone ) )
+				)
+				->withTitle( $this->get_the_title() );
+
+		$authors = $this->get_the_authors();
+		foreach ( $authors as $author ) {
+			$author_obj = Author::create();
+			if ( $author->display_name ) {
+				$author_obj->withName( $author->display_name );
+			}
+			if ( $author->bio ) {
+				$author_obj->withDescription( $author->bio );
+			}
+			if ( $author->user_url ) {
+				$author_obj->withURL( $author->user_url );
+			}
+			$header->addAuthor( $author );
 		}
-		include $template;
-		
+		$kicker = $this->get_the_kicker();
+		if ( $kicker ) {
+			$header->withKicker( $kicker );
+		}
+		$cover = $this->get_the_featured_image();
+		if ( $cover['src'] ) {
+			$image = Image::create()->withURL( $cover['src'] );
+			if ( isset( $cover['caption'] ) && strlen( $cover['caption'] ) > 0 ) {
+				$image->withCaption(
+				    Caption::create()->withTitle( $cover['caption'] )
+				);
+			}
+
+			$header->withCover( $image );
+		}
+		$this->instant_article =
+			InstantArticle::create()
+				->withCanonicalUrl( $this->get_canonical_url() )
+				->withHeader( $header );
+
+		if ( function_exists( 'wpcom_vip_file_get_contents' ) ) {
+			$configuration = wpcom_vip_file_get_contents( plugins_url( 'rules-configuration.json', __FILE__ ) );
+		} else {
+			$configuration = file_get_contents( plugins_url( 'rules-configuration.json', __FILE__ ) );
+		}
+
+		$transformer = new Transformer();
+		$this->transformer = $transformer;
+		$transformer->loadRules( $configuration );
+
+		$transformer = apply_filters( 'instant_articles_transformer_rules_loaded', $transformer );
+
+		$settings_publishing = Instant_Articles_Option_Publishing::get_option_decoded();
+
+		if (
+			isset ( $settings_publishing['custom_rules_enabled'] ) &&
+			! empty( $settings_publishing['custom_rules_enabled'] ) &&
+			isset ( $settings_publishing['custom_rules'] ) &&
+			! empty( $settings_publishing['custom_rules'] )
+		) {
+			$transformer->loadRules( $settings_publishing['custom_rules'] );
+		}
+
+		$transformer = apply_filters( 'instant_articles_transformer_custom_rules_loaded', $transformer );
+
+		$libxml_previous_state = libxml_use_internal_errors( true );
+		$document = new DOMDocument( '1.0', get_option( 'blog_charset' ) );
+		$content = $this->get_the_content();
+
+		// DOMDocument isn’t handling encodings too well, so let’s help it a little.
+		if ( function_exists( 'mb_convert_encoding' ) ) {
+			$content = mb_convert_encoding( $content, 'HTML-ENTITIES', get_option( 'blog_charset' ) );
+		}
+
+		$result = $document->loadHTML( '<!doctype html><html><body>' . $content . '</body></html>' );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $libxml_previous_state );
+
+		$document = apply_filters( 'instant_articles_parsed_document', $document );
+
+		if ( $result ) {
+			$transformer->transform( $this->instant_article, $document );
+		}
+
+		$this->add_ads_from_settings();
+		$this->add_analytics_from_settings();
+
 		/**
-	     * Fires after the instant article is rendered
+	     * Fires after the instant article is rendered.
 	     *
 	     * @since 0.1
-	     * @param Instant_Article_Post  $instant_article_post  The instant article post
+	     * @param Instant_Article_Post  $instant_article_post  The instant article post.
 	     */
-		do_action( 'instant_articles_after_render_post', $this );
+		do_action( 'instant_articles_after_transform_post', $this );
+
+		return $this->instant_article;
 	}
 
 	/**
-	 * Article <head> style
+	 * Add all ad code(s) to the Header of an InstantArticle.
+	 *
+	 * @since 0.3
+	 */
+	public function add_ads_from_settings() {
+		$header = $this->instant_article->getHeader();
+
+		$settings_ads = Instant_Articles_Option_Ads::get_option_decoded();
+
+		$width = 300;
+		$height = 250;
+
+		$dimensions_match = [];
+		$dimensions_raw = isset( $settings_ads['dimensions'] ) ? $settings_ads['dimensions'] : null;
+		if ( preg_match( '/^(?:\s)*(\d+)x(\d+)(?:\s)*$/', $dimensions_raw, $dimensions_match ) ) {
+			$width = intval( $dimensions_match[1] );
+			$height = intval( $dimensions_match[2] );
+		}
+
+		$ad = Ad::create()
+			->enableDefaultForReuse()
+			->withWidth( $width )
+			->withHeight( $height );
+
+		$source_of_ad = isset( $settings_ads['ad_source'] ) ? $settings_ads['ad_source'] : 'none';
+		switch ( $source_of_ad ) {
+
+			case 'none':
+				break;
+
+			case 'fan':
+				if ( ! empty( $settings_ads['fan_placement_id'] ) ) {
+					$placement_id = $settings_ads['fan_placement_id'];
+
+					$ad->withSource(
+						add_query_arg(
+							array(
+								'placement' => $placement_id,
+								'adtype' => 'banner' . $width . 'x' . $height,
+							),
+							'https://www.facebook.com/adnw_request'
+						)
+					);
+
+					$header->addAd( $ad );
+				}
+				break;
+
+			case 'iframe':
+				if ( ! empty( $settings_ads['iframe_url'] ) ) {
+					$ad->withSource(
+						$settings_ads['iframe_url']
+					);
+
+					$header->addAd( $ad );
+				}
+				break;
+
+			case 'embed':
+				if ( ! empty( $settings_ads['embed_code'] ) ) {
+
+					$document = new DOMDocument();
+					$fragment = $document->createDocumentFragment();
+					$valid_html = @$fragment->appendXML( $settings_ads['embed_code'] );
+
+					if ( $valid_html ) {
+						$ad->withHTML(
+							$fragment
+						);
+						$header->addAd( $ad );
+					}
+				}
+				break;
+
+			default:
+				if ( ! empty( $source_of_ad ) ) {
+					$registered_compat_ads = Instant_Articles_Option::get_registered_compat( 'instant_articles_compat_registry_ads' );
+					foreach ( $registered_compat_ads as $compat_id => $compat_info ) {
+						if ( array_key_exists( $compat_id, $registered_compat_ads ) ) {
+
+							$document = new DOMDocument();
+							$fragment = $document->createDocumentFragment();
+							$valid_html = @$fragment->appendXML( $compat_info['payload'] );
+
+							if ( $valid_html ) {
+								$ad = Ad::create()
+									->enableDefaultForReuse()
+									->withWidth( $width )
+									->withHeight( $height )
+									->withHTML(
+										$fragment
+									);
+
+								$header->addAd( $ad );
+							}
+						}
+					}
+				}
+				break;
+		}
+
+		$this->instant_article->enableAutomaticAdPlacement();
+	}
+
+	/**
+	 * Add all analytic tracking code(s) an InstantArticle.
+	 *
+	 * @since 0.3
+	 */
+	public function add_analytics_from_settings() {
+		$settings_analytics = Instant_Articles_Option_Analytics::get_option_decoded();
+
+		if ( isset( $settings_analytics['embed_code_enabled'] ) && ! empty( $settings_analytics['embed_code'] ) ) {
+
+			$document = new DOMDocument();
+			$fragment = $document->createDocumentFragment();
+			$valid_html = @$fragment->appendXML( $settings_analytics['embed_code'] );
+
+			if ( $valid_html ) {
+				$this->instant_article
+					->addChild(
+						Analytics::create()
+							->withHTML(
+								$fragment
+							)
+					);
+			}
+		}
+
+		if ( ! empty( $settings_analytics['integrations'] ) ) {
+			$settings_analytics_compats = $settings_analytics['integrations'];
+			$registered_compat_analytics = Instant_Articles_Option::get_registered_compat( 'instant_articles_compat_registry_analytics' );
+			foreach ( $registered_compat_analytics as $compat_id => $compat_info ) {
+				if ( in_array( $compat_id, $settings_analytics_compats, true ) ) {
+
+					$document = new DOMDocument();
+					$fragment = $document->createDocumentFragment();
+					$valid_html = @$fragment->appendXML( $compat_info['payload'] );
+
+					if ( $valid_html ) {
+						$this->instant_article
+							->addChild(
+								Analytics::create()
+									->withHTML(
+										$fragment
+									)
+							);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Article <head> style.
 	 *
 	 * @since 0.1
-	 * @return string The article style
+	 * @return string The article style.
 	 */
-	function get_article_style() {
+	public function get_article_style() {
 
 		/**
-	     * Filter the article style to use
+	     * Filter the article style to use.
 	     *
 	     * @since 0.1
 	     * @param string                    $template               Path to the current (default) template.
-	     * @param Instant_Article_Post      $instant_article_post   The instant article post
+	     * @param Instant_Article_Post      $instant_article_post   The instant article post.
 	     */
 		$article_style = apply_filters( 'instant_articles_style', 'default', $this );
 
 		return $article_style;
 	}
-
 }
-
-
-

--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+use Facebook\InstantArticles\Client\Client;
+use Facebook\Facebook;
+
+/**
+ * Class responsible for drawing the meta box on the post edit page
+ *
+ * @since 0.1
+ */
+class Instant_Articles_Publisher {
+
+	/**
+	 * Inits publisher.
+	 */
+	public static function init() {
+		add_action( 'save_post', array( 'Instant_Articles_Publisher', 'submit_article' ), 10, 2 );
+	}
+
+	/**
+	 * Submits article to Instant Articles.
+	 *
+	 * @param string $post_id The identifier of post.
+	 * @param Post   $post The WP Post.
+	 */
+	public static function submit_article( $post_id, $post ) {
+
+		// Don't process if this is just a revision or an autosave.
+		if ( wp_is_post_revision( $post ) || wp_is_post_autosave( $post ) ) {
+			return;
+		}
+
+		// Transform the post to an Instant Article.
+		$adapter = new Instant_Articles_Post( $post );
+		$article = $adapter->to_instant_article();
+
+		// Instantiate an API client.
+		try {
+			$fb_app_settings = Instant_Articles_Option_FB_App::get_option_decoded();
+			$fb_page_settings = Instant_Articles_Option_FB_Page::get_option_decoded();
+			$publishing_settings = Instant_Articles_Option_Publishing::get_option_decoded();
+
+			$dev_mode = boolval(
+				isset( $publishing_settings['dev_mode'] ) ? $publishing_settings['dev_mode'] : false
+			);
+
+			if ( isset( $fb_app_settings['app_id'] )
+				&& isset( $fb_app_settings['app_secret'] )
+				&& isset( $fb_page_settings['page_access_token'] )
+				&& isset( $fb_page_settings['page_id'] ) ) {
+
+				$client = Client::create(
+					$fb_app_settings['app_id'],
+					$fb_app_settings['app_secret'],
+					$fb_page_settings['page_access_token'],
+					$fb_page_settings['page_id'],
+					$dev_mode
+				);
+
+				if ( $dev_mode ) {
+					$take_live = false;
+				} else {
+					// Any publish status other than 'publish' means draft for the Instant Article.
+					$take_live = 'publish' === $post->post_status;
+				}
+
+				try {
+					// Import the article.
+					$client->importArticle( $article, $take_live );
+				} catch ( Exception $e ) {
+					// Try without taking live for pages not yet reviewed.
+					$client->importArticle( $article, false );
+				}
+			}
+		} catch ( Exception $e ) {
+			Logger::getLogger( 'instantarticles-wp-plugin' )->error(
+				'Unable to submit article.',
+				$e->getTraceAsString()
+			);
+		}
+	}
+}

--- a/compat.php
+++ b/compat.php
@@ -1,20 +1,27 @@
 <?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
 
-// Load compat layer for Co-Authors Plus
+// Load compat layer for Co-Authors Plus.
 if ( function_exists( 'get_coauthors' ) && ! defined( 'CAP_IA_COMPAT' ) ) {
-	include(  dirname( __FILE__ ) . '/compat/class-instant-articles-co-authors-plus.php' );
+	include( dirname( __FILE__ ) . '/compat/class-instant-articles-co-authors-plus.php' );
 	$cap = new Instant_Articles_Co_Authors_Plus;
 	$cap->init();
 }
 
-// Load compat layer for Yoast SEO
+// Load compat layer for Yoast SEO.
 if ( defined( 'WPSEO_VERSION' ) && ! defined( 'WPSEO_IA_COMPAT' ) ) {
-	include(  dirname( __FILE__ ) . '/compat/class-instant-articles-yoast-seo.php' );
+	include( dirname( __FILE__ ) . '/compat/class-instant-articles-yoast-seo.php' );
 	$yseo = new Instant_Articles_Yoast_SEO;
 	$yseo->init();
 }
 
-// Load support for Google Analytics for WordPress (Google Analytics by Yoast)
+// Load support for Google Analytics for WordPress (Google Analytics by Yoast).
 if ( defined( 'GAWP_VERSION' ) && ! defined( 'GAWP_IA_COMPAT' ) ) {
 	include( dirname( __FILE__ ) . '/compat/class-instant-articles-google-analytics-for-wordpress.php' );
 	$gawp = new Instant_Articles_Google_Analytics_For_WordPress;
@@ -28,3 +35,7 @@ if ( defined( 'JETPACK__VERSION' ) ) {
 	$jp->init();
 }
 
+// Load compat layer for facebook embeds.
+include( dirname( __FILE__ ) . '/compat/class-instant-articles-facebook-embed.php' );
+$facebok_embed = new Instant_Articles_Facebook_Embed;
+$facebok_embed->init();

--- a/compat/class-instant-articles-co-authors-plus.php
+++ b/compat/class-instant-articles-co-authors-plus.php
@@ -1,33 +1,38 @@
 <?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
 
 /**
  * Compatibility layer for Co-Authors Plus
  *
  * @since 0.1
- *
  */
 class Instant_Articles_Co_Authors_Plus {
 
 	/**
-	 * Init the compat layer
-	 *
+	 * Init the compat layer.
 	 */
 	function init() {
 		add_filter( 'instant_articles_authors', array( $this, 'authors' ), 10, 2 );
 	}
 
 	/**
-	 * Filter the authors
+	 * Filter the authors.
 	 *
-	 * @param array  $authors  The current authors
-	 * @param int    $post_id  The current post ID
+	 * @param array $authors The current authors.
+	 * @param int   $post_id The current post ID.
 	 */
 	function authors( $authors, $post_id ) {
 		if ( function_exists( 'get_coauthors' ) ) {
 			$coauthors = get_coauthors( $post_id );
 
 			$authors = array();
-			foreach( $coauthors as $coauthor ) {
+			foreach ( $coauthors as $coauthor ) {
 
 				$author = new stdClass;
 				$author->ID            = $coauthor->ID;
@@ -46,5 +51,4 @@ class Instant_Articles_Co_Authors_Plus {
 
 		return $authors;
 	}
-
 }

--- a/compat/class-instant-articles-facebook-embed.php
+++ b/compat/class-instant-articles-facebook-embed.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+use Facebook\InstantArticles\Elements\Analytics;
+
+/**
+ * Support class for Facebook Embeds on Instant Articles
+ *
+ * @since 0.1
+ */
+class Instant_Articles_Facebook_Embed {
+
+	/**
+	 * Initiator for the embed. Simply adds the filter hook: 'instant_articles_parsed_document'.
+	 */
+	function init() {
+		add_filter( 'instant_articles_parsed_document', array( $this, 'wrap_facebook_embed' ), 10, 1 );
+	}
+
+	/**
+	 * This returns the string content to the javascript code that consists on the FB startup script code.
+	 *
+	 * @param DOMDocument $document The document container that will hold the embed.
+	 */
+	function render_sdk( $document ) {
+		$fragment = $document->createDocumentFragment();
+		$script = $document->createElement( 'script' );
+		$script_code =
+			'(function(d, s, id) {
+				var js, fjs = d.getElementsByTagName(s)[0];
+				if (d.getElementById(id)) return;
+				js = d.createElement(s); js.id = id;
+				js.src = "//connect.facebook.net/pt_BR/sdk.js#xfbml=1&version=v2.5&appId=349537438510572";
+				fjs.parentNode.insertBefore(js, fjs);
+			}(document, "script", "facebook-jssdk"));';
+
+		$script->appendChild( $document->createTextNode( $script_code ) );
+		$root = $document->createElement( 'div' );
+		$root->setAttribute( 'id', 'fb-root' );
+		$fragment->appendChild( $root );
+		$fragment->appendChild( $script );
+		return $fragment;
+	}
+
+	/**
+	 * Wraps the embed into a div with class "embed" to be easily converted into InstantArticle object structure.
+	 *
+	 * @param DOMDocument $document the document holder of the embed.
+	 */
+	function wrap_facebook_embed( $document ) {
+		$xpath = new DOMXpath( $document );
+		$node_list = $xpath->query( "//div[starts-with(@class, 'fb-')]" );
+		foreach ( $node_list as $node ) {
+			$wrapped = $document->createElement( 'div' );
+			$wrapped->setAttribute( 'class', 'embed' );
+			$wrapped->appendChild( $this->render_sdk( $document ) );
+			$wrapped->appendChild( $node->cloneNode( true ) );
+			if ( $node->parentNode ) {
+				$node->parentNode->replaceChild( $wrapped, $node );
+			}
+		}
+
+		return $document;
+	}
+}

--- a/compat/class-instant-articles-google-analytics-for-wordpress.php
+++ b/compat/class-instant-articles-google-analytics-for-wordpress.php
@@ -4,25 +4,55 @@
  * Support class for Google Analytics for WordPress (Google Analytics by Yoast)
  *
  * @since 0.1
- *
  */
 class Instant_Articles_Google_Analytics_For_WordPress {
 
 	/**
-	 * Init the compat layer
+	 * File and path for analytics.
 	 *
+	 * @var string $plugin_file File and path of googleanalytics.
+	 */
+	public static $plugin_file = 'google-analytics-for-wordpress/googleanalytics.php';
+
+	/**
+	 * Init the compat layer
 	 */
 	function init() {
-		add_filter( 'instant_articles_content', array( $this, 'add_ga_code' ), 10, 1 );
+		add_action( 'instant_articles_compat_registry_analytics', array( $this, 'add_to_registry' ) );
 	}
 
 	/**
-	 * Add the GA tracking code to the end of the content
+	 * Adds identifying information about this 3rd party plugin
+	 * to the wider registry.
 	 *
-	 * @since 0.1
-	 * @param string  $content  The post content.
+	 * @since 0.3
+	 * @param array $registry Reference param. The registry where it will be stored.
 	 */
-	function add_ga_code( $content ) {
+	function add_to_registry( &$registry ) {
+		$path_to_plugin = WP_PLUGIN_DIR . '/' . self::$plugin_file;
+		$plugin_data = get_plugin_data( $path_to_plugin );
+
+		$display_name = $plugin_data['Name'];
+
+		// TextDomain isn't required so we create our own in case it's missing.
+		$identifier = isset( $plugin_data['TextDomain'] )
+			? $plugin_data['TextDomain']
+			: sanitize_title( $display_name );
+
+		$embed_code = $this->get_raw_embed_code();
+
+		$registry[ $identifier ] = array(
+			'name' => $display_name,
+			'payload' => $embed_code,
+		);
+	}
+
+	/**
+	 * Returns the GA tracking code
+	 *
+	 * @since 0.3
+	 */
+	function get_raw_embed_code() {
 
 		$options = Yoast_GA_Options::instance()->options;
 
@@ -36,15 +66,6 @@ class Instant_Articles_Google_Analytics_For_WordPress {
 		$tracker->tracking();
 		$ga_code = ob_get_clean();
 
-		if ( strlen( $ga_code ) ) {
-			$ga = '<figure class="op-tracker"><iframe>';
-			$ga .= $ga_code;
-			$ga .= '</iframe></figure>';
-
-			$content .= $ga;
-		}
-
-		return $content;
+		return $ga_code;
 	}
-
 }

--- a/compat/class-instant-articles-yoast-seo.php
+++ b/compat/class-instant-articles-yoast-seo.php
@@ -1,41 +1,39 @@
 <?php
-
 /**
  * Compatibility layer for Yoast SEO
  *
  * @since 0.1
- *
  */
 class Instant_Articles_Yoast_SEO {
 
 	/**
-	 * Init the compat layer
-	 *
+	 * Init the compat layer.
 	 */
 	function init() {
 		add_filter( 'instant_articles_featured_image', array( $this, 'override_featured_image' ), 10, 2 );
-		add_filter( 'instant_articles_authors', array( $this, 'user_url' ), 11 , 2 ); // Hook in after other author modifications (like the Co-Authors Plus plugin)
+		// Hook in after other author modifications (like the Co-Authors Plus plugin).
+		add_filter( 'instant_articles_authors', array( $this, 'user_url' ), 11 , 2 );
 	}
 
 	/**
-	 * Override the featured image with the one set for Facebook
+	 * Override the featured image with the one set for Facebook.
 	 *
 	 * @since 0.1
-	 * @param array  $image data  The current image data
-	 * @param int    $post_id  The instant article post
-	 * @return array The filtered image data
+	 * @param array $image_data  The current image data.
+	 * @param int   $post_id  The instant article post.
+	 * @return array The filtered image data.
 	 */
 	function override_featured_image( $image_data, $post_id ) {
 
 		$image_url = get_post_meta( $post_id, '_yoast_wpseo_opengraph-image', true );
 
 		if ( strlen( $image_url ) ) {
-			$image_data[ 'src' ] = $image_url;
+			$image_data['src'] = $image_url;
 
 			$desc = get_post_meta( $post_id, '_yoast_wpseo_opengraph-description', true );
 
 			if ( strlen( $desc ) ) {
-				$image_data[ 'caption' ] = $desc;
+				$image_data['caption'] = $desc;
 			}
 		}
 
@@ -43,12 +41,12 @@ class Instant_Articles_Yoast_SEO {
 	}
 
 	/**
-	 * Use the facebook URL as user_url if no other is set
+	 * Use the facebook URL as user_url if no other is set.
 	 *
 	 * @since 0.1
-	 * @param array  $authors  The current post author(s).
-	 * @param int    $post_id  The instant article post
-	 * @return array The filtered authors
+	 * @param array $authors  The current post author(s).
+	 * @param int   $post_id  The instant article post.
+	 * @return array The filtered authors.
 	 */
 	function user_url( $authors, $post_id ) {
 
@@ -64,6 +62,5 @@ class Instant_Articles_Yoast_SEO {
 
 		return $authors;
 
-	} 
-
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "php": ">=5.4",
+        "masterminds/html5": "2.*",
+        "symfony/css-selector": "*",
+        "facebook/php-sdk-v4": "~5.0",
+        "apache/log4php": "2.3.0",
+        "facebook/facebook-instant-articles-sdk-php": "0.6.2"
+    }
+}

--- a/css/instant-articles-meta-box.css
+++ b/css/instant-articles-meta-box.css
@@ -1,0 +1,92 @@
+.instant-articles-messages {
+	margin-left: 15px;
+	margin-top: 0px;
+}
+
+.instant-articles-messages li {
+	display: table-row;
+}
+
+.instant-articles-messages li > div,
+.instant-articles-messages li > span {
+	display: table-cell;
+}
+
+.instant-articles-messages li > div {
+	padding-left: 5px;
+}
+
+.instant-articles-transformer-markup {
+	display: none;
+}
+
+.instant-articles-show-debug .instant-articles-transformer-markup {
+	display: block;
+}
+
+.instant-articles-messages li .message span {
+	display: none;
+}
+
+.instant-articles-messages li:hover .message span {
+	display: block;
+	position: absolute;
+	width: 50%;
+	height: auto;
+	border: 1px solid #bb9;
+	padding: 5px;
+	background: #ffe;
+	overflow-y: auto;
+	color: #666;
+	margin: 10px;
+}
+.instant-articles-transformer-markup {
+	border-top: 1px dashed #ccc;
+	padding-top: 10px;
+	margin-top: 10px;
+}
+.instant-articles-transformer-markup div {
+	width: 50%;
+	float: left;
+	box-sizing: padding-box;
+}
+
+.instant-articles-transformer-markup div textarea {
+	width: 100%;
+	height: 400px;
+}
+
+/* Spinner code */
+@keyframes instant_articles_spinner {
+	to {transform: rotate(360deg);}
+}
+
+@-webkit-keyframes instant_articles_spinner {
+	to {-webkit-transform: rotate(360deg);}
+}
+
+.instant_articles_spinner {
+	min-width: 24px;
+	min-height: 24px;
+	margin: 20px;
+}
+
+.instant_articles_spinner:before {
+	content: 'Loading…';
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 16px;
+	height: 16px;
+	margin-top: -10px;
+	margin-left: -10px;
+}
+
+.instant_articles_spinner:not(:required):before {
+	content: '';
+	border-radius: 50%;
+	border-top: 2px solid #03ade0;
+	border-right: 2px solid transparent;
+	animation: instant_articles_spinner .6s linear infinite;
+	-webkit-animation: instant_articles_spinner .6s linear infinite;
+}

--- a/css/instant-articles-settings-wizard.css
+++ b/css/instant-articles-settings-wizard.css
@@ -1,0 +1,54 @@
+ol.instant-articles-wizard-steps {
+	margin: 0;
+	padding-bottom: 20px;
+	list-style: none;
+	counter-reset: ia-plugin-wizard-counter;
+}
+ol.instant-articles-wizard-steps > li {
+	position: relative;
+	margin: 0;
+	margin-left: 20px;
+	padding-left: 40px;
+}
+ol.instant-articles-wizard-steps > li.current:before {
+	color: #46b450;
+	border-color: #46b450;
+}
+ol.instant-articles-wizard-steps > li.complete:before {
+	content: '✓';
+	color: white;
+	background-color: #46b450;
+	border-color: #46b450;
+}
+ol.instant-articles-wizard-steps > li:before {
+	position: absolute;
+	top: 0px;
+	left: -0.6em;
+	width: 1.2em;
+	height: 1.2em;
+	line-height: 1.2em;
+	border: 3px solid #ccc;
+	border-radius: 50%;
+	background-color: white;
+	color: #ccc;
+	font-size: 22pt;
+	font-weight: bold;
+	text-align: center;
+	content: counter(ia-plugin-wizard-counter);
+	counter-increment: ia-plugin-wizard-counter;
+}
+ol.instant-articles-wizard-steps h3 {
+	cursor: pointer;
+	padding-top: 0.6em;
+}
+ol.instant-articles-wizard-steps .step-details {
+	display: none;
+	margin-bottom: 20px;
+}
+ol.instant-articles-wizard-steps > li.current .step-details {
+	display: block;
+}
+
+#instant-articles-restart-wizard button:before {
+	content: "\f516";
+}

--- a/embeds.php
+++ b/embeds.php
@@ -1,16 +1,14 @@
 <?php
-
 /**
- * Oembed/embed handling
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * The embed result is most likely cached, so we have to handle it late. If it is not cached and we handle it early, it will be cached with an unwanted result
- * for regular posts. So we resort to parsing the embed result in the embed_oembed_html and embed_handler_html filters.
+ * @package default
  */
-
 
 /**
  * Remove all extra oembed html filters added by themes and plugins.
- *
  */
 remove_all_filters( 'embed_oembed_html' );
 
@@ -18,37 +16,37 @@ remove_all_filters( 'embed_oembed_html' );
  * Filter the oembed results to see if we should do some extra handling
  *
  * @since 0.1
- * @param string  $html     The original HTML returned from the external oembed provider
- * @param string  $url      The URL found in the content
- * @param mixed   $attr     An array with extra attributes
- * @param int     $post_ID  The post ID
- * @return string  The potentially filtered HTML
+ * @param string $html     The original HTML returned from the external oembed provider.
+ * @param string $url      The URL found in the content.
+ * @param mixed  $attr     An array with extra attributes.
+ * @param int    $post_id  The post ID.
+ * @return string The potentially filtered HTML.
  */
-function instant_articles_embed_oembed_html( $html, $url, $attr, $post_ID ) {
+function instant_articles_embed_oembed_html( $html, $url, $attr, $post_id ) {
 
 	if ( ! class_exists( 'WP_oEmbed' ) ) {
 		include_once( ABSPATH . WPINC . '/class-oembed.php' );
 	}
 
-	// Instead of checking all possible URL variants, use the provider list from WP_oEmbed
-	$WP_oEmbed = new WP_oEmbed();
-	$providerURL = $WP_oEmbed->get_provider( $url );
+	// Instead of checking all possible URL variants, use the provider list from WP_oEmbed.
+	$wp_oembed = new WP_oEmbed();
+	$provider_url = $wp_oembed->get_provider( $url );
 
 	$provider_name = false;
-	if ( false !== strpos( $providerURL, 'instagram.com' ) ) {
+	if ( false !== strpos( $provider_url, 'instagram.com' ) ) {
 		$provider_name = 'instagram';
-	} elseif( false !== strpos( $providerURL, 'twitter.com' ) ) {
+	} elseif ( false !== strpos( $provider_url, 'twitter.com' ) ) {
 		$provider_name = 'twitter';
-	} elseif( false !== strpos( $providerURL, 'youtube.com' ) ) {
+	} elseif ( false !== strpos( $provider_url, 'youtube.com' ) ) {
 		$provider_name = 'youtube';
-	} elseif( false !== strpos( $providerURL, 'vine.co' ) ) {
+	} elseif ( false !== strpos( $provider_url, 'vine.co' ) ) {
 		$provider_name = 'vine';
 	}
 
 	$provider_name = apply_filters( 'instant_articles_social_embed_type', $provider_name, $url );
 
 	if ( $provider_name ) {
-		$html = instant_articles_embed_get_html( $provider_name, $html, $url, $attr, $post_ID );
+		$html = instant_articles_embed_get_html( $provider_name, $html, $url, $attr, $post_id );
 	}
 
 	return $html;
@@ -58,74 +56,41 @@ add_filter( 'embed_oembed_html', 'instant_articles_embed_oembed_html', 10, 4 );
 
 
 /**
- * Filter the embed results for embeds
+ * Filter the embed results for embeds.
  *
  * @since 0.1
- * @param string  $provider_name  The name of the embed provider. E.g. “instagram” or “youtube”
- * @param string  $html           The original HTML returned from the external oembed/embed provider
- * @param string  $url            The URL found in the content
- * @param mixed   $attr           An array with extra attributes
- * @param int     $post_ID        The post ID
- * @return string  The filtered HTML
+ * @param string $provider_name  The name of the embed provider. E.g. “instagram” or “youtube”.
+ * @param string $html           The original HTML returned from the external oembed/embed provider.
+ * @param string $url            The URL found in the content.
+ * @param mixed  $attr           An array with extra attributes.
+ * @param int    $post_id        The post ID.
+ * @return string The filtered HTML.
  */
-function instant_articles_embed_get_html( $provider_name, $html, $url, $attr, $post_ID ) {
-
-	/*
-	Example output from instagram:
-	<blockquote class="instagram-media" data-instgrm-version="6" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;">
-	<div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:50.0% 0; text-align:center; width:100%;">
-	<div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAGFBMVEUiIiI9PT0eHh4gIB4hIBkcHBwcHBwcHBydr+JQAAAACHRSTlMABA4YHyQsM5jtaMwAAADfSURBVDjL7ZVBEgMhCAQBAf//42xcNbpAqakcM0ftUmFAAIBE81IqBJdS3lS6zs3bIpB9WED3YYXFPmHRfT8sgyrCP1x8uEUxLMzNWElFOYCV6mHWWwMzdPEKHlhLw7NWJqkHc4uIZphavDzA2JPzUDsBZziNae2S6owH8xPmX8G7zzgKEOPUoYHvGz1TBCxMkd3kwNVbU0gKHkx+iZILf77IofhrY1nYFnB/lQPb79drWOyJVa/DAvg9B/rLB4cC+Nqgdz/TvBbBnr6GBReqn/nRmDgaQEej7WhonozjF+Y2I/fZou/qAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"/>
-	</div>
-	<p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/6l9z5RTbAN/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A photo posted by BjÃ¸rn Johansen (@bjornjohansen)</a> on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2015-08-20T05:19:53+00:00">Aug 19, 2015 at 10:19pm PDT</time></p>
-	</div>
-	</blockquote>
-	<p><script async="" defer="defer" src="//platform.instagram.com/en_US/embeds.js"/></p>
-	*/
-
-	/*
-	Example output from twitter:
-	<blockquote class="twitter-tweet" width="550"><p lang="en" dir="ltr">Will my Drupal site upgrade itself automatically to version 8, or do I click a button somewhere?</p>
-	<p>— BjÃ¸rn Johansen (@bjornjohansen) <a href="https://twitter.com/bjornjohansen/status/667263124794417152">November 19, 2015</a></p>
-	</blockquote>
-	<p><script async="" src="//platform.twitter.com/widgets.js" charset="utf-8"/></p>
-	*/
-
-	/*
-	Example output from youtube:
-	<iframe width="660" height="371" src="https://www.youtube.com/embed/SQjSJ0T7PiE?feature=oembed" frameborder="0" allowfullscreen></iframe>
-	*/
-
-	/*
-	Example output from vine:
-	<iframe class="vine-embed" src="https://vine.co/v/e9U7gav5e5h/embed/simple" width="660" height="660" frameborder="0"/><script async="" src="//platform.vine.co/static/scripts/embed.js"/>
-	*/
+function instant_articles_embed_get_html( $provider_name, $html, $url, $attr, $post_id ) {
 
 	/**
-	 * Filter the HTML that will go into the Instant Article Social Embed markup
+	 * Filter the HTML that will go into the Instant Article Social Embed markup.
 	 *
 	 * @since 0.1
-	 * @param string  $html     The HTML
-	 * @param string  $url      The URL found in the content
-	 * @param mixed   $attr     An array with extra attributes
-	 * @param int     $post_ID  The post ID
+	 * @param string $html     The HTML.
+	 * @param string $url      The URL found in the content.
+	 * @param mixed  $attr     An array with extra attributes.
+	 * @param int    $post_id  The post ID.
 	 */
-	$html = apply_filters( "instant_articles_social_embed_{$provider_name}", $html, $url, $attr, $post_ID);
+	$html = apply_filters( "instant_articles_social_embed_{$provider_name}", $html, $url, $attr, $post_id );
 
-	$html = sprintf( '<figure class="op-social"><iframe>%s</iframe></figure>', $html );
+	$html = sprintf( '<div class="embed">%s</div>', $html );
 
 	/**
-	 * Filter the Instant Article Social Embed markup 
+	 * Filter the Instant Article Social Embed markup.
 	 *
 	 * @since 0.1
-	 * @param string  $html     The Social Embed markup
-	 * @param string  $url      The URL found in the content
-	 * @param mixed   $attr     An array with extra attributes
-	 * @param int     $post_ID  The post ID
+	 * @param string $html     The Social Embed markup.
+	 * @param string $url      The URL found in the content.
+	 * @param mixed  $attr     An array with extra attributes.
+	 * @param int    $post_id  The post ID.
 	 */
-	$html = apply_filters( 'instant_articles_social_embed', $html, $url, $attr, $post_ID );
+	$html = apply_filters( 'instant_articles_social_embed', $html, $url, $attr, $post_id );
 
 	return $html;
 }
-
-
-

--- a/feed-template.php
+++ b/feed-template.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
 header( 'Content-Type: ' . feed_content_type( 'rss2' ) . '; charset=' . get_option( 'blog_charset' ), true );
 echo '<?xml version="1.0" encoding="' . esc_attr( get_option( 'blog_charset' ) ) . '"?' . '>';
 
@@ -7,28 +15,30 @@ $last_modified = null;
 <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
 	<channel>
 		<title><?php bloginfo_rss( 'name' ); ?> - <?php esc_html_e( 'Instant Articles', 'instant-articles' ); ?></title>
-		<link><?php bloginfo_rss('url') ?></link>
+		<link><?php bloginfo_rss( 'url' ) ?></link>
 		<description><?php bloginfo_rss( 'description' ) ?></description>
 		<?php while ( have_posts() ) : the_post(); ?>
 			<?php
-			$instant_article_post = new Instant_Articles_Post( get_the_ID() );
-			
+			$instant_article_post = new Instant_Articles_Post( get_post( get_the_id() ) );
+
 			// If we’re OK with a limited post set: Do not include posts with empty content -- FB will complain.
 			if ( defined( 'INSTANT_ARTICLES_LIMIT_POSTS' ) && INSTANT_ARTICLES_LIMIT_POSTS && ! strlen( trim( $instant_article_post->get_the_content() ) ) ) {
 				continue;
 			}
 
-			// Posts are sorted by modification time, so our first accepted post should be the one last modified
+			// Posts are sorted by modification time, so our first accepted post should be the one last modified.
 			if ( is_null( $last_modified ) ) {
 				$last_modified = $instant_article_post->get_the_moddate_iso();
 			}
 			?>
 			<item>
-				<title><?php echo esc_html( $instant_article_post->get_the_title_rss() ); ?></title>
+				<title><?php echo esc_html( $instant_article_post->get_the_title() ); ?></title>
 				<link><?php echo esc_url( $instant_article_post->get_canonical_url() ); ?></link>
-				<content:encoded><![CDATA[<?php $instant_article_post->render(); ?>]]></content:encoded>
+				<content:encoded>
+					<![CDATA[<?php echo $instant_article_post->to_instant_article()->render(); ?>]]>
+				</content:encoded>
 				<guid isPermaLink="false"><?php esc_html( the_guid() ); ?></guid>
-				<description><![CDATA[<?php echo esc_html( $instant_article_post->get_the_excerpt_rss() ); ?>]]></description>
+				<description><![CDATA[<?php echo esc_html( $instant_article_post->get_the_excerpt() ); ?>]]></description>
 				<pubDate><?php echo esc_html( $instant_article_post->get_the_pubdate_iso() ); ?></pubDate>
 				<modDate><?php echo esc_html( $instant_article_post->get_the_moddate_iso() ); ?></modDate>
 				<?php $authors = $instant_article_post->get_the_authors(); ?>

--- a/js/instant-articles-meta-box.js
+++ b/js/instant-articles-meta-box.js
@@ -1,0 +1,15 @@
+function instant_articles_load_meta_box ( post_ID ) {
+	jQuery( document ).ready( function( $ ) {
+		var data = {
+			'action': 'instant_articles_meta_box',
+			'post_ID': post_ID
+		};
+		jQuery.post( ajaxurl, data, function(response) {
+			jQuery( '#instant_article_meta_box .inside' ).html( response );
+		}, 'html' );
+		jQuery( '#instant_article_meta_box' ).delegate( '.instant-articles-toggle-debug', 'click', function () {
+			jQuery( '#instant_article_meta_box' ).toggleClass( 'instant-articles-show-debug' );
+			return false;
+		} );
+	});
+}

--- a/js/instant-articles-option-ads.js
+++ b/js/instant-articles-option-ads.js
@@ -1,0 +1,42 @@
+jQuery( function () {
+	var idAdSource       = '#' + INSTANT_ARTICLES_OPTION_ADS['option_field_id_source'];
+	var idFanPlacementId = '#' + INSTANT_ARTICLES_OPTION_ADS['option_field_id_fan'];
+	var idIframeUrl      = '#' + INSTANT_ARTICLES_OPTION_ADS['option_field_id_iframe'];
+	var idEmbedCode      = '#' + INSTANT_ARTICLES_OPTION_ADS['option_field_id_embed'];
+	var idDimensions     = '#' + INSTANT_ARTICLES_OPTION_ADS['option_field_id_dimensions'];
+	var $rowFanPlacementId = jQuery( idFanPlacementId ).parents( 'tr' );
+	var $rowIframeUrl      = jQuery( idIframeUrl )     .parents( 'tr' );
+	var $rowEmbedCode      = jQuery( idEmbedCode )     .parents( 'tr' );
+	var $rowDimensions     = jQuery( idDimensions )    .parents( 'tr' );
+	jQuery( idAdSource ).change( function () {
+		switch (jQuery( this ).val()) {
+			case 'fan':
+				$rowFanPlacementId.show();
+				$rowIframeUrl     .hide();
+				$rowEmbedCode     .hide();
+				$rowDimensions    .show();
+			break;
+
+			case 'iframe':
+				$rowFanPlacementId.hide();
+				$rowIframeUrl     .show();
+				$rowEmbedCode     .hide();
+				$rowDimensions    .show();
+			break;
+
+			case 'embed':
+				$rowFanPlacementId.hide();
+				$rowIframeUrl     .hide();
+				$rowEmbedCode     .show();
+				$rowDimensions    .show();
+			break;
+
+			default:
+				$rowFanPlacementId.hide();
+				$rowIframeUrl     .hide();
+				$rowEmbedCode     .hide();
+				$rowDimensions    .hide();
+			break;
+		}
+	} ).trigger( 'change' );
+} );

--- a/js/instant-articles-option-analytics.js
+++ b/js/instant-articles-option-analytics.js
@@ -1,0 +1,17 @@
+jQuery( function () {
+	var idEmbedCodeEnabled  = '#' + INSTANT_ARTICLES_OPTION_ANALYTICS['option_field_id_embed_code_enabled'];
+	var idEmbedCode         = '#' + INSTANT_ARTICLES_OPTION_ANALYTICS['option_field_id_embed_code'];
+	var $rowEmbedCode = jQuery( idEmbedCode ).parents( 'tr' );
+	var $embedCodeEnabled = jQuery( idEmbedCodeEnabled );
+	$embedCodeEnabled.change( function () {
+		if ( $embedCodeEnabled.is( ':checked' ) ) {
+
+			$rowEmbedCode.show();
+
+		} else {
+
+			$rowEmbedCode.hide();
+
+		}
+	} ).trigger( 'change' );
+} );

--- a/js/instant-articles-option-publishing.js
+++ b/js/instant-articles-option-publishing.js
@@ -1,0 +1,17 @@
+jQuery( function () {
+	var idCustomRulesEnabled  = '#' + INSTANT_ARTICLES_OPTION_PUBLISHING['option_field_id_custom_rules_enabled'];
+	var idCustomRules         = '#' + INSTANT_ARTICLES_OPTION_PUBLISHING['option_field_id_custom_rules'];
+	var $rowCustomRules = jQuery( idCustomRules ).parents( 'tr' );
+	var $customRulesEnabled = jQuery( idCustomRulesEnabled );
+	$customRulesEnabled.change( function () {
+		if ( $customRulesEnabled.is( ':checked' ) ) {
+
+			$rowCustomRules.show();
+
+		} else {
+
+			$rowCustomRules.hide();
+
+		}
+	} ).trigger( 'change' );
+} );

--- a/js/instant-articles-settings.js
+++ b/js/instant-articles-settings.js
@@ -1,0 +1,17 @@
+jQuery( function () {
+	jQuery( '#instant-articles-fb-page-selector' ).change(function () {
+		var val = jQuery( this ).val();
+		var obj = jQuery.parseJSON( val );
+
+		if ( val ) {
+			jQuery( '[data-step-id="page-selection"] input[type="submit"]' ).attr( 'disabled', false );
+			jQuery.each( obj, function ( key, value ) {
+				jQuery( 'input[name="instant-articles-option-fb-page[' + key + ']"]' )
+					.val( value );
+			});
+		}
+		else {
+			jQuery( '[data-step-id="page-selection"] input[type="submit"]' ).attr( 'disabled', true );
+		}
+	} ).trigger( 'change' );
+} );

--- a/meta-box/class-instant-articles-meta-box.php
+++ b/meta-box/class-instant-articles-meta-box.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+use Facebook\InstantArticles\Client\Client;
+use Facebook\InstantArticles\Client\InstantArticleStatus;
+use Facebook\InstantArticles\Client\ServerMessage;
+use Facebook\Exceptions\FacebookResponseException;
+
+/**
+ * Class responsible for drawing the meta box on the post edit page
+ *
+ * @since 0.1
+ */
+class Instant_Articles_Meta_Box {
+
+	/**
+	 * Initiator for Metabox.
+	 */
+	public static function init() {
+		add_action( 'add_meta_boxes', array( 'Instant_Articles_Meta_Box', 'register_meta_box' ) );
+		add_action(
+			'wp_ajax_instant_articles_meta_box',
+			array( 'Instant_Articles_Meta_Box', 'render_meta_box' )
+		);
+	}
+
+	/**
+	 * Register Meta Box renderer.
+	 */
+	public static function register_meta_box() {
+		add_meta_box(
+			'instant_article_meta_box',
+			'Facebook Instant Articles',
+			array( 'Instant_Articles_Meta_Box', 'render_meta_box_loader' ),
+			'post',
+			'normal',
+			'default'
+		);
+	}
+
+	/**
+	 * Includes the template for Metabox.
+	 *
+	 * @param Post $post the post request content.
+	 */
+	public static function render_meta_box_loader( $post ) {
+		include( dirname( __FILE__ ) . '/meta-box-loader-template.php' );
+	}
+
+	/**
+	 * Renderer for the Metabox.
+	 */
+	public static function render_meta_box() {
+		$post = get_post( intval( filter_input( INPUT_POST, 'post_ID' ) ) );
+		$adapter = new Instant_Articles_Post( $post );
+		$article = $adapter->to_instant_article();
+		$canonical_url = $adapter->get_canonical_url();
+		$submission_status = null;
+
+		Instant_Articles_Settings::menu_items();
+		$settings_page_href = Instant_Articles_Settings::get_href_to_settings_page();
+
+		try {
+			$fb_app_settings = Instant_Articles_Option_FB_App::get_option_decoded();
+			$fb_page_settings = Instant_Articles_Option_FB_Page::get_option_decoded();
+
+			if ( isset( $fb_app_settings['app_id'] )
+				&& isset( $fb_app_settings['app_secret'] )
+				&& isset( $fb_page_settings['page_access_token'] )
+				&& isset( $fb_page_settings['page_id'] ) ) {
+				// Instantiate a new Client to get the status of this article.
+				$client = Client::create(
+					$fb_app_settings['app_id'],
+					$fb_app_settings['app_secret'],
+					$fb_page_settings['page_access_token'],
+					$fb_page_settings['page_id']
+				);
+
+				// Grab the latest status of this article and display.
+				$article_id = $client->getArticleIDFromCanonicalURL( $canonical_url );
+				$submission_status = $client->getLastSubmissionStatus( $article_id );
+			}
+		} catch ( FacebookResponseException $e ) {
+			$submission_status = null;
+		}
+
+		include( dirname( __FILE__ ) . '/meta-box-template.php' );
+
+		die();
+	}
+}

--- a/meta-box/meta-box-loader-template.php
+++ b/meta-box/meta-box-loader-template.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+?>
+<span class="instant_articles_spinner" ></span>
+
+<script>
+	instant_articles_load_meta_box( <?php echo absint( $post->ID ); ?> );
+</script>

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+use Facebook\InstantArticles\Client\InstantArticleStatus;
+use Facebook\InstantArticles\Client\ServerMessage;
+?>
+
+<!-- Submission status -->
+<?php if ( $submission_status ) : ?>
+
+	<!-- Display the last submission status -->
+	<?php switch ( $submission_status->getStatus() ) :
+		case InstantArticleStatus::SUCCESS : ?>
+			<p>
+				<b>
+					<span class="dashicons dashicons-yes"></span>
+					Your article was submitted to Instant Articles successfully
+				</b>
+			</p>
+			<?php break; ?>
+
+		<?php case InstantArticleStatus::FAILED : ?>
+			<p>
+				<b>
+					<span class="dashicons dashicons-no-alt"></span>
+					It wasn't possible to submit your article
+				</b>
+			</p>
+			<?php break; ?>
+
+		<?php case InstantArticleStatus::IN_PROGRESS : ?>
+			<p>
+				<b>
+					<span class="dashicons dashicons-update"></span>
+					Your article is being submitted...
+				</b>
+			</p>
+			<script>
+				setTimeout(function () {
+					instant_articles_load_meta_box( <?php echo absint( $post->ID ); ?> );
+				}, 2000);
+			</script>
+
+			<?php break; ?>
+
+		<?php default : ?>
+			<p>
+				<b>
+					<span class="dashicons dashicons-no-alt"></span>
+					This post was not yet submitted to Instant Articles.
+				</b>
+			</p>
+			<?php break; ?>
+
+	<?php endswitch; ?>
+
+
+	<!-- Display the submission messages if any -->
+	<?php if ( ! empty( $submission_status->getMessages() ) ) : ?>
+
+		<p>The server responded with the following messages:</p>
+
+		<ul class="instant-articles-messages">
+
+			<?php foreach ( $submission_status->getMessages() as $message ) : ?>
+
+				<?php switch ( $message->getLevel() ) :
+					case ServerMessage::WARNING : ?>
+						<li class="wp-ui-text-highlight">
+							<span class="dashicons dashicons-warning"></span>
+							<div>
+								<?php echo esc_html( $message->getMessage() ); ?>
+							</div>
+						</li>
+						<?php break; ?>
+
+					<?php case ServerMessage::ERROR : ?>
+						<li class="wp-ui-text-notification">
+							<span class="dashicons dashicons-dismiss"></span>
+							<div>
+								<?php echo esc_html( $message->getMessage() ); ?>
+							</div>
+						</li>
+						<?php break; ?>
+
+					<?php case ServerMessage::FATAL : ?>
+						<li class="wp-ui-text-notification">
+							<span class="dashicons dashicons-sos"></span>
+							<div>
+								<?php echo esc_html( $message->getMessage() ); ?>
+							</div>
+						</li>
+						<?php break; ?>
+
+					<?php default: ?>
+						<li class="wp-ui-text-highlight">
+							<span class="dashicons dashicons-info"></span>
+							<div>
+								<?php echo esc_html( $message->getMessage() ); ?>
+							</div>
+						</li>
+
+				<?php endswitch; ?>
+
+			<?php endforeach; ?>
+			</ul>
+
+	<?php endif; ?>
+
+<?php else : ?>
+
+	<p>
+		<b>
+			<span class="dashicons dashicons-no-alt"></span>
+			Could not connect to your page. Please check the
+			<a href="<?php echo esc_url( $settings_page_href ); ?>">Instant Articles plugin settings</a>.
+		</b>
+	</p>
+
+<?php endif; ?>
+
+
+<!-- Transformer messages -->
+<?php if ( ! empty( $adapter->transformer->getWarnings() ) ) : ?>
+	<p>
+		<span class="dashicons dashicons-warning"></span>
+		This post was transformed into an Instant Article with some warnings
+		<a href="#" class="instant-articles-toggle-debug">
+			(toggle debug information)
+		</a>
+	</p>
+	<ul class="instant-articles-messages">
+		<?php foreach ( $adapter->transformer->getWarnings() as $warning ) : ?>
+			<li class="wp-ui-text-highlight">
+				<span class="dashicons dashicons-warning"></span>
+				<div class="message">
+					<?php echo esc_html( $warning ); ?>
+					<span>
+						<?php
+							echo esc_html(
+								$warning->getNode()->ownerDocument->saveHTML( $warning->getNode() )
+							);
+						?>
+					</span>
+				</div>
+				</dl>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+
+<?php else : ?>
+	<p>
+		<span class="dashicons dashicons-yes"></span>
+		This post was transformed into an Instant Article with no warnings
+		<a href="#" class="instant-articles-toggle-debug">
+			(toggle debug information)
+		</a>
+	</p>
+<?php endif; ?>
+
+<div class="instant-articles-transformer-markup">
+	<div>
+		<label for="source">Source Markup:</label>
+		<textarea class="source" readonly><?php echo esc_textarea( $adapter->get_the_content() ); ?></textarea>
+	</div>
+	<div>
+		<label for="transformed">Transformed Markup:</label>
+		<textarea class="source" readonly><?php echo esc_textarea( $article->render( '', true ) ); ?></textarea>
+	</div>
+	<br clear="all">
+</div>

--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -1,0 +1,250 @@
+{
+    "rules":
+    [{
+        "class": "TextNodeRule"
+    }, {
+        "class": "PassThroughRule",
+        "selector": "html"
+    }, {
+        "class": "PassThroughRule",
+        "selector": "head"
+    }, {
+        "class": "PassThroughRule",
+        "selector": "body"
+    }, {
+        "class": "PassThroughRule",
+        "selector" : "code"
+    },{
+        "class": "PassThroughRule",
+        "selector" : "del"
+    }, {
+        "class": "PassThroughRule",
+        "selector" : "span"
+    }, {
+        "class": "ParagraphRule",
+        "selector": "p"
+    }, {
+        "class": "LineBreakRule",
+        "selector": "br"
+    }, {
+        "class": "AnchorRule",
+        "selector": "a",
+        "properties": {
+            "anchor.href": {
+                "type": "string",
+                "selector": "a",
+                "attribute": "href"
+            },
+            "anchor.rel": {
+                "type": "string",
+                "selector": "a",
+                "attribute": "rel"
+            }
+        }
+    }, {
+        "class": "BoldRule",
+        "selector": "b"
+    }, {
+        "class": "BoldRule",
+        "selector": "strong"
+    }, {
+        "class": "ItalicRule",
+        "selector": "i"
+    }, {
+        "class": "ItalicRule",
+        "selector": "em"
+    }, {
+        "class": "BlockquoteRule",
+        "selector": "blockquote"
+    }, {
+        "class": "ImageRule",
+        "selector": "//p[img]",
+        "properties": {
+            "image.url": {
+                "type": "string",
+                "selector": "img",
+                "attribute": "src"
+            },
+            "image.caption": {
+                "type": "element",
+                "selector": "img"
+            }
+        }
+    },{
+        "class": "ImageRule",
+        "selector": "img",
+        "properties": {
+            "image.url": {
+                "type": "string",
+                "selector": "img",
+                "attribute": "src"
+            },
+            "image.caption": {
+                "type": "element",
+                "selector": "img[@alt]"
+            }
+        }
+    }, {
+        "class": "CaptionRule",
+        "selector": "img",
+        "properties": {
+            "caption.default": {
+                "type": "string",
+                "selector": "img",
+                "attribute": "alt"
+            }
+        }
+    }, {
+        "class": "ListItemRule",
+        "selector" : "li"
+    }, {
+        "class": "ListElementRule",
+        "selector" : "ul"
+    }, {
+        "class": "ListElementRule",
+        "selector" : "ol"
+    }, {
+        "class": "BlockquoteRule",
+        "selector" : "blockquote"
+    }, {
+        "class": "H1Rule",
+        "selector" : "h1",
+        "properties" : {
+            "h1.class" : {
+                "type" : "string",
+                "selector" : "link",
+                "attribute": "class"
+            }
+        }
+    }, {
+        "class": "H1Rule",
+        "selector" : "title"
+    }, {
+        "class": "H2Rule",
+        "selector" : "h2",
+        "properties" : {
+            "h2.class" : {
+                "type" : "string",
+                "selector" : "link",
+                "attribute": "class"
+            }
+        }
+    },
+    {
+        "class": "SocialEmbedRule",
+        "selector" : "iframe",
+        "properties" : {
+            "socialembed.url" : {
+                "type" : "string",
+                "selector" : "iframe",
+                "attribute": "src"
+            },
+            "socialembed.iframe" : {
+                "type" : "children",
+                "selector" : "iframe"
+            },
+            "socialembed.caption" : {
+                "type" : "element",
+                "selector" : "figcaption"
+            }
+        }
+    }, {
+        "class": "SocialEmbedRule",
+        "selector" : "//p[iframe]",
+        "properties" : {
+            "socialembed.url" : {
+                "type" : "string",
+                "selector" : "iframe",
+                "attribute": "src"
+            },
+            "socialembed.iframe" : {
+                "type" : "children",
+                "selector" : "iframe"
+            },
+            "socialembed.caption" : {
+                "type" : "element",
+                "selector" : "figcaption"
+            }
+        }
+    },{
+        "class": "SocialEmbedRule",
+        "selector" : "div.embed",
+        "properties" : {
+            "socialembed.iframe" : {
+                "type" : "children",
+                "selector" : "div.embed"
+            }
+        }
+    }, {
+        "class": "SocialEmbedRule",
+        "selector" : "//div[@class='embed' and iframe]",
+        "properties" : {
+            "socialembed.url" : {
+                "type" : "string",
+                "selector" : "iframe",
+                "attribute": "src"
+            }
+        }
+    }, {
+        "class": "ImageRule",
+        "selector": "//p[a[img]]|//a[img]",
+        "properties": {
+            "image.url": {
+                "type": "string",
+                "selector": "img",
+                "attribute": "src"
+            },
+            "image.caption": {
+                "type": "element",
+                "selector": "img[@alt]"
+            }
+        }
+    }, {
+        "class": "SlideshowImageRule",
+        "selector" : "figure",
+        "properties" : {
+            "image.url" : {
+                "type" : "string",
+                "selector" : "img",
+                "attribute": "src"
+            },
+            "caption.title" : {
+                "type" : "string",
+                "selector" : "figcaption"
+            }
+        }
+    }, {
+        "class": "SlideshowRule",
+        "selector" : "div.gallery"
+    }, {
+        "class": "CaptionRule",
+        "selector" : "figcaption"
+    },
+    {
+        "class": "ImageRule",
+        "selector" : "figure",
+        "properties" : {
+            "image.url" : {
+                "type" : "string",
+                "selector" : "img",
+                "attribute": "src"
+            }
+        }
+    }, {
+        "class": "VideoRule",
+        "selector" : "div.wp-video",
+        "containsChild": "video",
+        "properties" : {
+            "video.url" : {
+                "type" : "string",
+                "selector" : "source",
+                "attribute": "src"
+            },
+            "video.type" : {
+                "type" : "string",
+                "selector" : "source",
+                "attribute": "type"
+            }
+        }
+    }]
+}

--- a/settings/class-instant-articles-option-ads.php
+++ b/settings/class-instant-articles-option-ads.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option.php' );
+
+/**
+ * Configuration class for Ads.
+ */
+class Instant_Articles_Option_Ads extends Instant_Articles_Option {
+
+	const OPTION_KEY = IA_PLUGIN_TEXT_DOMAIN . '-option-ads';
+
+	const SECTIONS = array(
+		'title' => 'Ads',
+		'description' => 'This is where you manage your ads.',
+	);
+
+	const FIELDS = array(
+
+		'ad_source' => array(
+			'label' => 'Ad Type',
+			'description' => 'Instant Articles supports both Audience Network and Direct Sold banner ads',
+			'render' => array( 'Instant_Articles_Option_Ads', 'custom_render_ad_source' ),
+			'select_options' => array(
+				'none' => 'No Ads',
+				'fan' => 'Facebook Audience Network',
+				'iframe' => 'Custom iframe URL',
+				'embed' => 'Custom Embed Code',
+			),
+			'default' => 'none',
+		),
+
+		'fan_placement_id' => array(
+			'label' => 'Audience Network Placement ID',
+			'description' => 'Find your Placement ID for Facebook Audience Network on your app\'s Audience Network Portal',
+			'default' => null,
+		),
+
+		'iframe_url' => array(
+			'label' => 'URL for iframe',
+			'placeholder' => '//ad-server.com/my-ad',
+			'default' => '',
+		),
+
+		'embed_code' => array(
+			'label' => 'Embed Code',
+			'render' => 'textarea',
+			'default' => '',
+			'placeholder' => '<script>...</script>',
+		),
+
+		'dimensions' => array(
+			'label' => 'Ad Dimensions',
+			'render' => 'select',
+			'select_options' => array(
+				'300x250' => 'Large (300 x 250)',
+				'320x50' => 'Small (320 x 50)',
+			),
+			'default' => '300x250',
+		),
+
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.4
+	 */
+	public function __construct() {
+		parent::__construct(
+			self::OPTION_KEY,
+			self::SECTIONS,
+			self::FIELDS
+		);
+		wp_localize_script( 'instant-articles-option-ads', 'INSTANT_ARTICLES_OPTION_ADS', array(
+			'option_field_id_source'     => self::OPTION_KEY . '-ad_source',
+			'option_field_id_fan'        => self::OPTION_KEY . '-fan_placement_id',
+			'option_field_id_iframe'     => self::OPTION_KEY . '-iframe_url',
+			'option_field_id_embed'      => self::OPTION_KEY . '-embed_code',
+			'option_field_id_dimensions' => self::OPTION_KEY . '-dimensions',
+		) );
+	}
+
+	/**
+	 * Renders the ad source.
+	 *
+	 * @param array $args configuration fields for the ad.
+	 * @since 0.4
+	 */
+	public static function custom_render_ad_source( $args ) {
+		$id = $args['label_for'];
+		$name = $args['serialized_with_group'] . '[ad_source]';
+
+		$description = isset( $args['description'] )
+			? '<p class="description">' . esc_html( $args['description'] ) . '</p>'
+			: '';
+
+		?>
+		<select
+			id="<?php echo esc_attr( $id ); ?>"
+			name="<?php echo esc_attr( $name ); ?>"
+		>
+		<?php foreach ( $args['select_options'] as $ad_source_key => $ad_source_name ) : ?>
+			<option
+				value="<?php echo esc_attr( $ad_source_key ); ?>"
+				<?php echo selected( self::$settings['ad_source'], $ad_source_key ) ?>
+			>
+			<?php echo esc_html( $ad_source_name ); ?>
+			</option>
+		<?php endforeach; ?>
+
+		<?php
+		$compat_plugins = parent::get_registered_compat( 'instant_articles_compat_registry_ads' );
+		asort( $compat_plugins );
+		if ( count( $compat_plugins ) > 0 ) :
+		?>
+			<optgroup
+				label="From Supported Plugins"
+			>
+			<?php foreach ( $compat_plugins as $ad_source_key => $ad_source_info ) : ?>
+				<option
+					value="<?php echo esc_attr( $ad_source_key ); ?>"
+					<?php echo selected( self::$settings['ad_source'], $ad_source_key ) ?>
+				>
+				<?php echo esc_html( $ad_source_info['name'] ); ?>
+				</option>
+			<?php endforeach; ?>
+			</optgroup>
+		<?php endif; ?>
+
+		?>
+		</select>
+		<?php echo $description; ?>
+		<?php
+	}
+
+	/**
+	 * Sanitize and return all the field values.
+	 *
+	 * This method receives a payload containing all value for its fields and
+	 * should return the same payload after having been sanitized.
+	 *
+	 * Do not, encode the payload as this is performed by the
+	 * universal_sanitize_and_encode_handler() of the parent class.
+	 *
+	 * @param array $field_values The array map with field values.
+	 * @since 0.5
+	 */
+	public function sanitize_option_fields( $field_values ) {
+		foreach ( $field_values as $field_id => $field_value ) {
+			$field = self::FIELDS[ $field_id ];
+
+			switch ( $field_id ) {
+				case 'ad_source':
+					$all_options = array();
+
+					$registered_compat_ads = Instant_Articles_Option::get_registered_compat(
+						'instant_articles_compat_registry_ads'
+					);
+
+					foreach ( $field['select_options'] as $option_id => $option_info ) {
+						$all_options[] = $option_id;
+					}
+					foreach ( $registered_compat_ads as $compat_id => $compat_info ) {
+						$all_options[] = $compat_id;
+					}
+
+					if ( ! in_array( $field_value, $all_options ) ) {
+						$field_values[ $field_id ] = $field['default'];
+						add_settings_error(
+							$field_id,
+							'invalid_option',
+							'Invalid Ad Source'
+						);
+					}
+				break;
+
+				case 'fan_placement_id':
+					if ( isset( $field_values['ad_source'] ) && 'fan' === $field_values['ad_source'] ) {
+						if (
+							! is_numeric( $field_values[ $field_id ] ) ||
+							strval( absint( $field_values[ $field_id ] ) ) !== $field_values[ $field_id ]
+						) {
+							add_settings_error(
+								$field_id,
+								'invalid_placement_id',
+								'Invalid Audience Network Placement ID provided'
+							);
+							$field_values[ $field_id ] = $field['default'];
+						} else {
+							$field_values[ $field_id ] = absint( $field_values[ $field_id ] );
+						}
+					}
+				break;
+
+				case 'iframe_url':
+					if ( isset( $field_values['ad_source'] ) && 'iframe' === $field_values['ad_source'] ) {
+						$url = $field_values[$field_id];
+						if ( substr( $url, 0, 2 ) === '//' ) {
+							// Allow URLs without protocol prefix
+							$url = 'http:' . $url;
+						}
+						$url = filter_var( $url , FILTER_VALIDATE_URL );
+						if ( ! $url ) {
+							$field_values[ $field_id ] = $field['default'];
+							add_settings_error(
+								$field_id,
+								'invalid_url',
+								'Invalid URL provided for Ad iframe'
+							);
+						}
+					}
+				break;
+
+				case 'embed_code':
+					if ( isset( $field_values['ad_source'] ) && 'embed' === $field_values['ad_source'] ) {
+						$document = new DOMDocument();
+						$fragment = $document->createDocumentFragment();
+						if ( ! @$fragment->appendXML( $field_values[ $field_id ] ) ) {
+							add_settings_error(
+								'embed_code',
+								'invalid_markup',
+								'Invalid HTML markup provided for ad custom embed code'
+							);
+						}
+					}
+				break;
+
+				case 'dimensions':
+					if ( isset( $field_values['ad_source'] ) && 'none' !== $field_values['ad_source'] ) {
+						if ( ! array_key_exists( $field_value, $field['select_options'] ) ) {
+							$field_values[ $field_id ] = $field['default'];
+							add_settings_error(
+								'embed_code',
+								'invalid_dimensions',
+								'Invalid dimensions provided for Ad'
+							);
+						}
+					}
+				break;
+			}
+		}
+
+		return $field_values;
+	}
+}

--- a/settings/class-instant-articles-option-analytics.php
+++ b/settings/class-instant-articles-option-analytics.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option.php' );
+
+/**
+ * Analytics configuration class.
+ */
+class Instant_Articles_Option_Analytics extends Instant_Articles_Option {
+
+	const OPTION_KEY = IA_PLUGIN_TEXT_DOMAIN . '-option-analytics';
+
+	const SECTIONS = array(
+		'title' => 'Analytics',
+		'description' => 'This is where you configure your analytics settings. If you already use a Wordpress Plugin to manage your analytics, look for it in <strong>3rd Party Integrations</strong>.',
+	);
+
+	const FIELDS = array(
+
+		'integrations' => array(
+			'label' => '3rd party integrations',
+			'render' => array( 'Instant_Articles_Option_Analytics', 'custom_render_integrations' ),
+			'default' => [],
+		),
+
+		'embed_code_enabled' => array(
+			'label' => 'Custom tracker',
+			'render' => 'checkbox',
+			'default' => false,
+			'checkbox_label' => 'Enable custom tracker code',
+		),
+
+		'embed_code' => array(
+			'label' => 'Custom tracker code',
+			'render' => 'textarea',
+			'placeholder' => '<script>...</script>',
+			'default' => '',
+		),
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.4
+	 */
+	public function __construct() {
+		parent::__construct(
+			self::OPTION_KEY,
+			self::SECTIONS,
+			self::FIELDS
+		);
+		wp_localize_script( 'instant-articles-option-analytics', 'INSTANT_ARTICLES_OPTION_ANALYTICS', array(
+			'option_field_id_embed_code_enabled' => self::OPTION_KEY . '-embed_code_enabled',
+			'option_field_id_embed_code'         => self::OPTION_KEY . '-embed_code',
+		) );
+	}
+
+	/**
+	 * Renders the markup for the `integrations` field.
+	 *
+	 * @param array $args The array with configuration of fields.
+	 * @since 0.4
+	 */
+	public static function custom_render_integrations( $args ) {
+		$name = $args['serialized_with_group'] . '[integrations][]';
+
+		$compat_plugins = parent::get_registered_compat( 'instant_articles_compat_registry_analytics' );
+
+		if ( empty( $compat_plugins ) ) {
+			?>
+			<em>
+				<?php echo esc_html( 'No supported analytics plugins are installed nor activated' ); ?>
+			</em>
+			<?php
+
+			return;
+		}
+
+		asort( $compat_plugins );
+		foreach ( $compat_plugins as $plugin_id => $plugin_info ) {
+			?>
+			<label>
+				<input
+					type="checkbox"
+					name="<?php echo esc_attr( $name ); ?>"
+					value="<?php echo esc_attr( $plugin_id ); ?>"
+					<?php echo checked( in_array( $plugin_id, self::$settings['integrations'], true ) ) ?>
+				>
+				<?php echo esc_html( $plugin_info['name'] ); ?>
+			</label>
+			<br />
+			<?php
+		}
+	}
+
+	/**
+	 * Sanitize and return all the field values.
+	 *
+	 * This method receives a payload containing all value for its fields and
+	 * should return the same payload after having been sanitized.
+	 *
+	 * Do not encode the payload as this is performed by the
+	 * universal_sanitize_and_encode_handler() of the parent class.
+	 *
+	 * @param array $field_values The values in an array mapped keys.
+	 * @since 0.5
+	 */
+	public function sanitize_option_fields( $field_values ) {
+		foreach ( $field_values as $field_id => $field_value ) {
+			$field = self::FIELDS[ $field_id ];
+
+			switch ( $field_id ) {
+				case 'embed_code':
+					if ( isset( $field_values['embed_code_enabled'] ) && $field_values['embed_code_enabled'] ) {
+						$document = new DOMDocument();
+						$fragment = $document->createDocumentFragment();
+						if ( ! @$fragment->appendXML( $field_values[ $field_id ] ) ) {
+							add_settings_error(
+								'embed_code',
+								'invalid_markup',
+								'Invalid HTML markup provided for custom analytics tracker code'
+							);
+						}
+					}
+
+				break;
+			}
+		}
+
+		return $field_values;
+	}
+}

--- a/settings/class-instant-articles-option-fb-app.php
+++ b/settings/class-instant-articles-option-fb-app.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option.php' );
+
+/**
+ * The Instant Articles FB app configuration.
+ */
+class Instant_Articles_Option_FB_App extends Instant_Articles_Option {
+
+	const OPTION_KEY = IA_PLUGIN_TEXT_DOMAIN . '-option-fb-app';
+
+	const SECTIONS = array(
+		'title' => '',
+		'description' => '',
+	);
+
+	const FIELDS = array(
+
+		'app_id' => array(
+			'label' => 'App ID',
+			'default' => '',
+		),
+
+		'app_secret' => array(
+			'label' => 'App Secret',
+			'render' => 'password',
+			'default' => '',
+		),
+
+	);
+
+	/**
+	 * Consturctor.
+	 *
+	 * @since 0.4
+	 */
+	public function __construct() {
+		$this->options_manager = new parent(
+			self::OPTION_KEY,
+			self::SECTIONS,
+			self::FIELDS,
+			/**
+			 * Register this Option on a specific page group (used as the first
+			 * argument of `register_setting()` and called by `settings_fields()`).
+			 *
+			 * @since 0.5
+			 */
+			Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD
+		);
+	}
+}

--- a/settings/class-instant-articles-option-fb-page.php
+++ b/settings/class-instant-articles-option-fb-page.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option.php' );
+
+/**
+ * FB Page configuration.
+ */
+class Instant_Articles_Option_FB_Page extends Instant_Articles_Option {
+
+	const OPTION_KEY = IA_PLUGIN_TEXT_DOMAIN . '-option-fb-page';
+
+	const SECTIONS = array(
+		'title' => '',
+		'description' => '',
+	);
+
+	const FIELDS = array(
+
+	'page_id' => array(
+		'visible' => false,
+		'label' => 'Page ID',
+		'default' => '',
+	),
+
+	'page_name' => array(
+		'visible' => false,
+		'label' => 'Page Name',
+		'default' => '',
+	),
+
+	'page_access_token' => array(
+		'visible' => false,
+		'label' => 'Page Access Token',
+		'default' => '',
+	),
+
+	'page_access_token_expiration' => array(
+		'visible' => false,
+		'label' => 'Page Token Expiration',
+		'default' => '',
+	),
+
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.4
+	 */
+	public function __construct() {
+		$this->options_manager = new parent(
+			self::OPTION_KEY,
+			self::SECTIONS,
+			self::FIELDS,
+			/**
+			 * Register this Option on a specific page group (used as the first
+			 * argument of `register_setting()` and called by `settings_fields()`).
+			 *
+			 * @since 0.5
+			 */
+			Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD
+		);
+	}
+}

--- a/settings/class-instant-articles-option-publishing.php
+++ b/settings/class-instant-articles-option-publishing.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option.php' );
+
+/**
+ * Class for publishing configuration.
+ */
+class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
+
+	const OPTION_KEY = IA_PLUGIN_TEXT_DOMAIN . '-option-publishing';
+
+	const SECTIONS = array(
+		'title' => 'Publishing Settings',
+	);
+
+	const FIELDS = array(
+
+		'dev_mode' => array(
+			'label' => 'Development Mode',
+			'description' => 'Submit articles to the development environment instead of production',
+			'render' => 'checkbox',
+			'default' => false,
+			'checkbox_label' => 'Enable development mode',
+		),
+
+		'custom_rules_enabled' => array(
+			'label' => 'Custom transformer rules',
+			'render' => 'checkbox',
+			'default' => '',
+			'checkbox_label' => 'Enable custom transformer rules',
+		),
+
+		'custom_rules' => array(
+			'label' => 'Custom rules JSON',
+			'render' => 'textarea',
+			'placeholder' => '{ "rules": [{ "class": "BoldRule", "selector": "span.bold" }, ... ] }',
+			'default' => '',
+		),
+
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.4
+	 */
+	public function __construct() {
+		parent::__construct(
+			self::OPTION_KEY,
+			self::SECTIONS,
+			self::FIELDS
+		);
+		wp_localize_script( 'instant-articles-option-publishing', 'INSTANT_ARTICLES_OPTION_PUBLISHING', array(
+			'option_field_id_custom_rules_enabled' => self::OPTION_KEY . '-custom_rules_enabled',
+			'option_field_id_custom_rules'         => self::OPTION_KEY . '-custom_rules'
+		) );
+	}
+
+	/**
+	 * Sanitize and return all the field values.
+	 *
+	 * This method receives a payload containing all value for its fields and
+	 * should return the same payload after having been sanitized.
+	 *
+	 * Do not encode the payload as this is performed by the
+	 * universal_sanitize_and_encode_handler() of the parent class.
+	 *
+	 * @param array $field_values array map with key field_id => value.
+	 * @since 0.5
+	 */
+	public function sanitize_option_fields( $field_values ) {
+		foreach ( $field_values as $field_id => $field_value ) {
+			$field = self::FIELDS[ $field_id ];
+
+			switch ( $field_id ) {
+				case 'dev_mode':
+					$field_values[ $field_id ] = (bool) $field_value
+						? (string) true
+						: (string) $field['default'];
+				break;
+
+				case 'custom_rules':
+					if ( isset( $field_values['custom_rules_enabled'] ) && $field_values['custom_rules_enabled'] ) {
+						$custom_rules_json = json_decode( $field_values['custom_rules'] );
+						if ( $custom_rules_json === null ) {
+							$field_values['custom_rules'] = $field['default'];
+							add_settings_error(
+								'custom_embed',
+								'invalid_json',
+								'Invalid JSON provided for custom rules code'
+							);
+						}
+					}
+				break;
+
+				default:
+					// Should never happen.
+				break;
+			}
+		}
+
+		return $field_values;
+	}
+}

--- a/settings/class-instant-articles-option-wizard.php
+++ b/settings/class-instant-articles-option-wizard.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option.php' );
+
+/**
+ * Class for wizard behavior.
+ */
+class Instant_Articles_Option_Wizard extends Instant_Articles_Option {
+
+	const OPTION_KEY = IA_PLUGIN_TEXT_DOMAIN . '-option-wizard';
+
+	const SECTIONS = array(
+		'title' => '',
+		'description' => '',
+	);
+
+	const FIELDS = array(
+
+	'sign_up' => array(
+		'visible' => false,
+		'label' => 'Whether then user sign up',
+		'default' => '',
+	),
+
+
+	'claimed_url' => array(
+		'visible' => false,
+		'label' => 'Whether then user claimed the URL',
+		'default' => '',
+	),
+
+	);
+
+	/**
+	 * Constructor for wizard.
+	 *
+	 * @since 0.4
+	 */
+	public function __construct() {
+		$this->options_manager = new parent(
+			self::OPTION_KEY,
+			self::SECTIONS,
+			self::FIELDS,
+			/**
+			 * Register this Option on a specific page group (used as the first
+			 * argument of `register_setting()` and called by `settings_fields()`).
+			 *
+			 * @since 0.5
+			 */
+			Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD
+		);
+	}
+}

--- a/settings/class-instant-articles-option.php
+++ b/settings/class-instant-articles-option.php
@@ -1,0 +1,436 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+/**
+ * Base class for configurations.
+ */
+class Instant_Articles_Option {
+
+	const PAGE_OPTION_GROUP = Instant_Articles_Settings::IA_PLUGIN_SETTINGS_SLUG;
+	const PAGE_OPTION_GROUP_WIZARD = self::PAGE_OPTION_GROUP . '-wizard';
+	const FIELDS = array();
+
+	/**
+	 * Settings for options.
+	 *
+	 * @var array $settings The settings for each option.
+	 */
+	public static $settings = [];
+
+	/**
+	 * The key for field.
+	 *
+	 * @var string $key The key for field.
+	 */
+	private $key;
+
+	/**
+	 * Each section.
+	 *
+	 * @var array $sections The sections where fields will be stored/showed.
+	 */
+	private $sections;
+
+	/**
+	 * Page options.
+	 *
+	 * @var array $page_option_group
+	 */
+	private $page_option_group;
+
+	/**
+	 * Contains all the fields for the option. Supported field properties:
+	 *
+	 * Id - String. COMING SOON (to avoid using the key as the identifier)
+	 * visible - Boolean. Use this to hide the entire row of the rendered field in the UI. Defaults to true.
+	 * disable - Boolean|Array. Use to place the `disabled` attribute on the field. For fields with multiple options (<select>) an Array containing keys of all disabled `select_options` can be defined. Defaults to false.
+	 * serialized_with_group - String|false/null. Controls whether a particular field of a setting is serialized with the group or saved as its own independant option. Defaults to true.
+	 * label - String|null. The label for the field.
+	 * description - String. The description for the field, rendered as additional information below the field.
+	 * render - String|Function. How the field should be rendered as. Non-strings are assumed to be a function for rendering the field (third parameter of `add_settings_field()`). If a String, it is meant to be any of the standard <form> input types (checkbox, radio, textarea, hidden, select, textarea, password etc.') and the rendering will be handled by self::universal_render_handler(); if not defined, "text" is assumed
+	 * select_options - Array. Defines the <options> for a checkbox (key of this Array is used as its `value` attribute). Only used if the `render` is "select".
+	 * radio_options - Array. TO BE IMPLEMENTED (should mimic the "select_options" functionality)
+	 * placeholder - String. Used as the `placeholder` attribute for the <form> field.
+	 * default - String|null. Used as a default value for the field when there is no value yet saved in the db.
+	 *
+	 * @var array $fields The fields for option and its properties.
+	 * @since 0.4
+	 */
+	private $fields;
+
+	/**
+	 * If $option_group is not specified, the Option will be registered with a
+	 * "default" page group (the first argument of `register_setting()` and called
+	 * by `settings_fields()`).
+	 *
+	 * @param string $option_key The ID for the field.
+	 * @param array  $sections The sections for each field.
+	 * @param array  $option_fields All the fields.
+	 * @param array  $option_group Optional, if not informed will use self::PAGE_OPTION_GROUP.
+	 * @since 0.4
+	 */
+	public function __construct( $option_key, $sections, $option_fields, $option_group = null ) {
+		$this->key = $option_key;
+		$this->sections = $sections;
+		$this->fields = $option_fields;
+		$this->page_option_group = null === $option_group
+			? self::PAGE_OPTION_GROUP
+			: $option_group;
+
+		$this->init();
+	}
+
+	/**
+	 * Option initiator.
+	 *
+	 * @since 0.4
+	 */
+	private function init() {
+		$saved_options = self::get_option_decoded( $this->key );
+
+		foreach ( $this->fields as $field_key => $field ) {
+			self::$settings[ $field_key ] = isset( $saved_options[ $field_key ] )
+				? $saved_options[ $field_key ]
+				: $field['default'];
+		}
+
+		$this->wp_bootstrap_register_option();
+		$this->wp_bootstrap_create_sections();
+		$this->wp_bootstrap_add_fields_to_section();
+	}
+
+	/**
+	 * Decodes the option.
+	 *
+	 * @param string $option_key to be returned.
+	 * @return array from a json decoded content.
+	 * @since 0.4
+	 */
+	public static function get_option_decoded( $option_key = null ) {
+		if ( ! isset( $option_key ) ) {
+			// Late Static Binding to use the const OPTION_KEY from the child class which called this function.
+			$option_key = static::OPTION_KEY;
+		}
+
+		$raw_data = get_option( $option_key );
+
+		// Hack which creates an empty setting if it doesn't yet exist.
+		// Temporary solution to an unknown oddity which is double-escaping the JSON
+		// data as a string when attempting to access a setting that doesn't exist.
+		if ( false === $raw_data ) {
+			add_option( $option_key );
+			$raw_data = get_option( $option_key );
+		}
+
+		return json_decode( $raw_data, true );
+	}
+
+	/**
+	 * Obtains the compat related to $action_tag.
+	 *
+	 * @param string $action_tag The tag registered compat will be retrieved.
+	 * @since 0.4
+	 */
+	public static function get_registered_compat( $action_tag ) {
+		$registered_compat_integrations = [];
+
+		do_action_ref_array(
+			$action_tag,
+			array( &$registered_compat_integrations )
+		);
+		return $registered_compat_integrations;
+	}
+
+	/**
+	 * Registers the sanitization and encoding handler.
+	 *
+	 * @since 0.4
+	 */
+	private function wp_bootstrap_register_option() {
+		register_setting(
+			$this->page_option_group,
+			$this->key,
+			array( $this, 'universal_sanitize_and_encode_handler' )
+		);
+	}
+
+	/**
+	 * Create title and description sections.
+	 *
+	 * @since 0.4
+	 */
+	private function wp_bootstrap_create_sections() {
+		$title = isset( $this->sections['title'] )
+			? $this->sections['title']
+			: '';
+
+		$description = isset( $this->sections['description'] )
+			? $this->sections['description']
+			: '';
+
+		add_settings_section(
+			$this->key,
+			esc_html( $title ),
+			function () use ( $description ) {
+				esc_html( $description );
+			},
+			$this->key
+		);
+	}
+
+	/**
+	 * Add fields to defined section.
+	 *
+	 * @since 0.4
+	 */
+	private function wp_bootstrap_add_fields_to_section() {
+		foreach ( $this->fields as $field_key => $field ) {
+			$standalone_id = $this->key . '-' . $field_key;
+
+			// Default values of arguments for renderer.
+			$renderer_args = array(
+				// The "label_for" arg causes WordPress to wrap the label of the field with a <label> tag.
+				'label_for' => $standalone_id,
+				'serialized_with_group' => $this->key,
+				'render' => 'text',
+				'value' => self::$settings[ $field_key ],
+			);
+
+			// Override default arguments for renderer.
+			foreach ( $field as $key => $val ) {
+				$renderer_args[ $key ] = $val;
+
+				// The WordPress do_settings_fields() will add a `class` attribute to
+				// the <tr> tag of the rendered output with value of anything defined in
+				// a "class" key of the args for the renderer.
+				// We force it to include a value of "hidden" since this class is
+				// defined in WordPress's global CSS with `display: none;`.
+				if ( 'visible' === $key && false === $val ) {
+					$renderer_args['class'] = ( ! empty( $renderer_args['class'] )
+						? $renderer_args['class'] . ' '
+						: '') . 'hidden';
+				}
+			}
+
+			$renderer_handle = 'string' === gettype( $renderer_args['render'] )
+				? array( 'Instant_Articles_Option', 'universal_render_handler' )
+				: $renderer_args['render'];
+
+			add_settings_field(
+				$standalone_id,
+				$field['label'],
+				$renderer_handle,
+				$this->key,
+				$this->key,
+				$renderer_args
+			);
+		}
+	}
+
+	/**
+	 * Function to render all fields with its labels and inputs.
+	 *
+	 * @param array $args array map with its field names and values.
+	 * @since 0.4
+	 */
+	public static function universal_render_handler( $args = null ) {
+		$id = isset( $args['label_for'] )
+			? $args['label_for']
+			: '';
+
+		$type = isset( $args['render'] ) && gettype( 'string' === $args['render'] )
+			? $args['render']
+			: 'text';
+
+		if ( ! empty( $args['value'] ) ) {
+			$option_value = $args['value'];
+		} elseif ( ! empty( $args['default'] ) ) {
+			$option_value = $args['default'];
+		} else {
+			$option_value = '';
+		}
+
+		// Determines correct values based on whether the settings option
+		// is intended to be serialized as a field of a parent option name.
+		if ( gettype( 'string' === $args['serialized_with_group'] ) ) {
+			$group = $args['serialized_with_group'];
+			$group_key = substr( $id, strlen( $group . '-' ) );
+			$name = $group . '[' . $group_key . ']';
+		} else {
+			$name = $id;
+		}
+
+		$placeholder = isset( $args['placeholder'] )
+			? $args['placeholder']
+			: '';
+
+		$attr_disabled = isset( $args['disable'] ) && true === $args['disable']
+			? disabled()
+			: '';
+
+		$field_description = isset( $args['description'] )
+			? esc_html( $args['description'] )
+			: '';
+
+		$field_checkbox_label = isset( $args['checkbox_label'] )
+			? $args['checkbox_label']
+			: '';
+
+		switch ( $type ) {
+			case 'hidden':
+				?>
+				<input
+					type="hidden"
+					name="<?php echo esc_attr( $name ) ?>"
+					id="<?php echo esc_attr( $id ) ?>"
+					value="<?php echo esc_attr( $option_value ); ?>"
+				/>
+				<?php if ( $field_description ) : ?>
+					<p class="description">
+						<?php echo $field_description; ?>
+					</p>
+				<?php endif; ?>
+				<?php
+				break;
+
+			case 'checkbox':
+				$attr_checked = checked( 1, $option_value, false );
+				?>
+				<label>
+					<input
+						type="checkbox"
+						value="1"
+						name="<?php echo esc_attr( $name ) ?>"
+						id="<?php echo esc_attr( $id ) ?>"
+						<?php echo esc_attr( $attr_checked ); ?>
+						<?php echo esc_attr( $attr_disabled ); ?>
+					/>
+					<?php echo esc_html( $field_checkbox_label ); ?>
+				</label>
+				<?php if ( $field_description ) : ?>
+					<p class="description">
+						<?php echo $field_description; ?>
+					</p>
+				<?php endif; ?>
+				<?php
+				break;
+
+			case 'select':
+				?>
+				<select
+					id="<?php echo esc_attr( $id ) ?>"
+					name="<?php echo esc_attr( $name ) ?>"
+					<?php echo esc_html( $attr_disabled ) ?>
+				>
+				<?php foreach ( $args['select_options'] as $option_key => $option_name ) : ?>
+					<option
+						value="<?php echo esc_attr( $option_key ) ?>"
+						<?php echo selected( $option_key, $option_value ) ?>
+						<?php echo isset( $args['disable'] )
+							&& gettype( $args['disable'] ) === 'array'
+							&& in_array( $option_key, $args['disable'], true )
+						? disabled()
+						: '';
+						?>
+					>
+					<?php echo esc_html( $option_name ); ?>
+					</option>
+				<?php endforeach; ?>
+				</select>
+				<?php if ( $field_description ) : ?>
+					<p class="description">
+						<?php echo $field_description; ?>
+					</p>
+				<?php endif; ?>
+				<?php
+				break;
+
+			case 'textarea':
+				?>
+				<textarea
+					name="<?php echo esc_attr( $name ) ?>"
+					id="<?php echo esc_attr( $id ) ?>"
+					<?php if ( $placeholder ) : ?>
+						placeholder="<?php echo esc_attr( $placeholder ); ?>"
+					<?php endif; ?>
+					<?php echo esc_attr( $attr_disabled ); ?>
+					class="large-text code"
+					rows="8"
+				><?php echo esc_html( $option_value ); ?></textarea>
+				<?php if ( $field_description ) : ?>
+					<p class="description">
+						<?php echo $field_description; ?>
+					</p>
+				<?php endif; ?>
+				<?php
+				break;
+
+			case 'text':
+			case 'password':
+			default:
+				?>
+				<input
+					type="<?php echo esc_attr( $type ) ?>"
+					name="<?php echo esc_attr( $name ) ?>"
+					id="<?php echo esc_attr( $id ) ?>"
+					<?php if ( $placeholder ) : ?>
+						placeholder="<?php echo esc_attr( $placeholder ) ?>"
+					<?php endif; ?>
+					<?php echo esc_attr( $attr_disabled ) ?>
+					value="<?php echo esc_attr( $option_value ) ?>"
+					class="regular-text"
+				/>
+				<?php if ( $field_description ) : ?>
+					<p class="description">
+						<?php echo $field_description; ?>
+					</p>
+				<?php endif; ?>
+				<?php
+				break;
+		}
+	}
+
+	/**
+	 * Intercepts the form data for an individual option on its way to the server.
+	 * Receives one argument containing the payload data and passes it along to
+	 * the child's own sanitation method. Returns an encoded payload for it
+	 * to continue its way to the server.
+	 *
+	 * @param array $payload map of fields and their values.
+	 * @return string encoded json with fields.
+	 * @since 0.5
+	 */
+	public function universal_sanitize_and_encode_handler( $payload ) {
+		// Handle empty payload.
+		if ( ! is_array( $payload ) ) {
+			$payload = array();
+		}
+
+		// Remove any fields which could have been injected into the payload client-side.
+		$allowed_payload = array_intersect_key( $payload, static::FIELDS );
+		$allowed_payload = $payload;
+
+		// Pass the value along to the Child class's method to perform sanitation on its fields.
+		$sanitized_payload = static::sanitize_option_fields( $allowed_payload );
+
+		// Encode the payload into JSON before it's sent off to be saved.
+		return wp_json_encode( $sanitized_payload );
+	}
+
+	/**
+	 * "Pass through" function. This should be overridden in child classes which
+	 * are responsible for sanitizing its own $field_values.
+	 *
+	 * @param array $field_values array of values for fields.
+	 * @since 0.5
+	 */
+	public function sanitize_option_fields( $field_values ) {
+		return $field_values;
+	}
+}

--- a/settings/class-instant-articles-settings-fb-page.php
+++ b/settings/class-instant-articles-settings-fb-page.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+/**
+ * Class responsible for functionality and rendering of the settings
+ *
+ * @since 0.4
+ */
+class Instant_Articles_Settings_FB_Page {
+
+	/**
+	 * Facebook Permissions.
+	 *
+	 * @var array $fb_app_permissions The permissions asked for FB user to list pages he manages.
+	 */
+	public static $fb_app_permissions = [ 'pages_manage_instant_articles', 'pages_show_list' ];
+
+	/**
+	 * SDK instance.
+	 *
+	 * @var Facebook $fb_sdk the instance reference to FB sdk
+	 */
+	public $fb_sdk;
+
+	/**
+	 * Settings structure.
+	 *
+	 * @var array $fb_app_settings The map data structure to store settings.
+	 */
+	protected $fb_app_settings;
+
+	/**
+	 * Constructor for Settings page.
+	 *
+	 * @since 0.4
+	 */
+	public function __construct() {
+		$this->fb_app_settings = Instant_Articles_Option_FB_App::get_option_decoded();
+
+		if ( isset( $this->fb_app_settings['app_id'] ) && isset( $this->fb_app_settings['app_secret'] ) ) {
+			$app_id = $this->fb_app_settings['app_id'];
+			$app_secret = $this->fb_app_settings['app_secret'];
+		}
+
+		if ( ! empty( $app_id ) && ! empty( $app_secret ) ) {
+			$this->fb_sdk = new Facebook\Facebook([
+				'app_id' => $app_id,
+				'app_secret' => $app_secret,
+				'default_graph_version' => 'v2.2',
+			]);
+
+			$this->render_settings_page_scripts();
+		}
+	}
+
+	/**
+	 * Gets the login url scaped.
+	 *
+	 * @since 0.4
+	 */
+	public function get_escaped_login_url() {
+		if ( isset( $this->fb_sdk ) ) {
+			$helper = $this->fb_sdk->getRedirectLoginHelper();
+
+			$login_url = $helper->getLoginUrl(
+				Instant_Articles_Settings::get_href_to_settings_page(),
+				self::$fb_app_permissions
+			);
+
+			return htmlspecialchars( $login_url );
+		}
+	}
+
+	/**
+	 * Retrieves granted permissions.
+	 *
+	 * @param string $access_token The user access token.
+	 * @since 0.5
+	 */
+	public function get_fb_permissions( $access_token ) {
+
+		$permissions = array();
+
+		if ( isset( $this->fb_sdk ) && $access_token ) {
+
+			try {
+				$permissions_query = $this->fb_sdk->get( '/me/permissions', $access_token );
+				$decoded_permissions = $permissions_query->getDecodedBody();
+				if ( isset( $decoded_permissions['data'] ) ) {
+					foreach ( $decoded_permissions['data'] as $permission ) {
+						if ( 'granted' === $permission['status'] ) {
+							$permissions[ $permission['permission'] ] = 'granted';
+						}
+					}
+				}
+			} catch (Facebook\Exceptions\FacebookResponseException $e) {
+				// When Graph returns an error.
+				Logger::getLogger( 'instantarticles-wp-plugin' )->error(
+					'Graph returned an error: '.$e->getMessage(),
+					$e->getTraceAsString()
+				);
+
+			} catch (Facebook\Exceptions\FacebookSDKException $e) {
+				// When validation fails or other local issues.
+				Logger::getLogger( 'instantarticles-wp-plugin' )->error(
+					'Facebook SDK returned an error: '.$e->getMessage(),
+					$e->getTraceAsString()
+				);
+
+			}
+		}
+
+		if ( isset( $permissions ) ) {
+			// Logged in.
+			return $permissions;
+		}
+	}
+
+	/**
+	 * Retrieves Facebook access token.
+	 *
+	 * @since 0.4
+	 */
+	public function get_fb_access_token() {
+		$access_token = null;
+
+		if ( isset( $this->fb_sdk ) ) {
+			$js_helper = $this->fb_sdk->getJavaScriptHelper();
+
+			try {
+				$access_token = $js_helper->getAccessToken();
+
+			} catch (Facebook\Exceptions\FacebookResponseException $e) {
+				// When Graph returns an error.
+				Logger::getLogger( 'instantarticles-wp-plugin' )->error(
+					'Graph returned an error: '.$e->getMessage(),
+					$e->getTraceAsString()
+				);
+
+			} catch (Facebook\Exceptions\FacebookSDKException $e) {
+				// When validation fails or other local issues.
+				Logger::getLogger( 'instantarticles-wp-plugin' )->error(
+					'Facebook SDK returned an error: '.$e->getMessage(),
+					$e->getTraceAsString()
+				);
+			}
+		}
+
+		if ( null !== $access_token ) {
+			// Logged in.
+			return $access_token;
+		}
+	}
+
+	/**
+	 * Render the page scripts.
+	 *
+	 * @since 0.4
+	 */
+	public function render_settings_page_scripts() {
+		$app_id = $this->fb_app_settings['app_id'];
+
+	?>
+		<script>
+			window.fbAsyncInit = function() {
+				FB.init({
+					appId      : <?php echo esc_html( $app_id ); ?>,
+					xfbml      : true,
+					version    : "v2.5",
+					cookie     : true
+				});
+			};
+
+			(function(d, s, id){
+				var js, fjs = d.getElementsByTagName(s)[0];
+				if (d.getElementById(id)) {return;}
+				js = d.createElement(s); js.id = id;
+				js.src = "//connect.facebook.net/en_US/sdk.js";
+				fjs.parentNode.insertBefore(js, fjs);
+			}(document, "script", "facebook-jssdk"));
+
+			function loginCallback(response) {
+				location.reload();
+			}
+		</script>
+		<?php
+	}
+}

--- a/settings/class-instant-articles-settings-wizard.php
+++ b/settings/class-instant-articles-settings-wizard.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+/**
+ * Class responsible for functionality and rendering of the Setup Wizard
+ *
+ * @since 0.5
+ */
+class Instant_Articles_Settings_Wizard {
+
+	const STEP_STATE_IDLE = 'idle';
+	const STEP_STATE_CURRENT = 'current';
+	const STEP_STATE_COMPLETE = 'complete';
+
+	const STEP_ID_IA_SIGNUP = 'ia-signup';
+	const STEP_ID_APP_SETUP = 'app-setup';
+	const STEP_ID_PAGE_SELECTION = 'page-selection';
+	const STEP_ID_CLAIM_URL = 'claim-url';
+	const STEP_ID_NEXT_STEPS = 'next-steps';
+
+	/**
+	 * Wizard steps.
+	 *
+	 * @var array $steps The steps for wizard
+	 */
+	private static $steps = array(
+		1 => self::STEP_ID_IA_SIGNUP,
+		2 => self::STEP_ID_APP_SETUP,
+		3 => self::STEP_ID_PAGE_SELECTION,
+		4 => self::STEP_ID_CLAIM_URL,
+		5 => self::STEP_ID_NEXT_STEPS,
+	);
+
+	/**
+	 * Returns the current step for the wizard.
+	 *
+	 * @since 0.5
+	 */
+	public static function get_current_step_id() {
+
+		$wizard_settings = Instant_Articles_Option_Wizard::get_option_decoded();
+		$fb_page_settings = Instant_Articles_Option_FB_Page::get_option_decoded();
+		$fb_app_settings = Instant_Articles_Option_FB_App::get_option_decoded();
+
+		if ( ! isset( $wizard_settings['sign_up'] ) ||  empty( $wizard_settings['sign_up'] ) ) {
+			return self::STEP_ID_IA_SIGNUP;
+		} elseif ( empty( $fb_app_settings['app_id'] ) || empty( $fb_app_settings['app_secret'] )  ) {
+			return self::STEP_ID_APP_SETUP;
+		} elseif ( empty( $fb_page_settings['page_id'] ) || empty( $fb_page_settings['page_name'] )  ) {
+			return self::STEP_ID_PAGE_SELECTION;
+		} elseif ( ! isset( $wizard_settings['claimed_url'] ) || empty( $wizard_settings['claimed_url'] ) ) {
+			return self::STEP_ID_CLAIM_URL;
+		} else {
+			return self::STEP_ID_NEXT_STEPS;
+		}
+	}
+
+
+	/**
+	 * Returns the current state of a step.
+	 *
+	 * @param int $step_id The step id of wizard.
+	 * @since 0.5
+	 */
+	public static function get_state_for_step( $step_id ) {
+		$current_step_id = self::get_current_step_id();
+
+		$step_number = array_search( $step_id, self::$steps );
+		$current_step_number = array_search( $current_step_id, self::$steps );
+
+		if ( $step_number === $current_step_number ) {
+			return self::STEP_STATE_CURRENT;
+		} elseif ( $step_number > $current_step_number ) {
+			return self::STEP_STATE_IDLE;
+		} else {
+			return self::STEP_STATE_COMPLETE;
+		}
+	}
+}

--- a/settings/class-instant-articles-settings.php
+++ b/settings/class-instant-articles-settings.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option-fb-page.php' );
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option-fb-app.php' );
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option-wizard.php' );
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option-ads.php' );
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option-analytics.php' );
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option-publishing.php' );
+
+require_once( dirname( __FILE__ ) . '/class-instant-articles-settings-wizard.php' );
+require_once( dirname( __FILE__ ) . '/class-instant-articles-settings-fb-page.php' );
+
+/**
+ * Class responsible for functionality and rendering of the settings.
+ *
+ * @since 0.4
+ */
+class Instant_Articles_Settings {
+
+	const IA_PLUGIN_SETTINGS_SLUG = IA_PLUGIN_TEXT_DOMAIN . '-settings';
+
+	/**
+	 * Initiator.
+	 *
+	 * @since 0.4
+	 */
+	public static function init() {
+		add_action( 'admin_menu', array( 'Instant_Articles_Settings', 'menu_items' ) );
+
+		add_filter( 'plugin_action_links_' . IA_PLUGIN_PATH, array( 'Instant_Articles_Settings', 'add_settings_link_to_plugin_actions' ) );
+
+		add_action( 'admin_init', function () {
+			new Instant_Articles_Option_FB_App();
+			new Instant_Articles_Option_FB_Page();
+			new Instant_Articles_Option_Wizard();
+			new Instant_Articles_Option_Ads();
+			new Instant_Articles_Option_Analytics();
+			new Instant_Articles_Option_Publishing();
+		});
+
+	}
+
+	/**
+	 * Gets the URL/path for this page.
+	 *
+	 * @since 0.4
+	 */
+	public static function get_href_to_settings_page() {
+		return menu_page_url( self::IA_PLUGIN_SETTINGS_SLUG, false );
+	}
+
+	/**
+	 * Creates an anchor element.
+	 *
+	 * @param array $links The links will be added to anchor.
+	 * @since 0.4
+	 */
+	public static function add_settings_link_to_plugin_actions( $links ) {
+		$link_text = __( 'Settings' );
+		$settings_href = self::get_href_to_settings_page();
+		$settings_link = '<a href="' . esc_url( $settings_href ) . '">' . $link_text . '</a>';
+		array_push( $links, $settings_link );
+		return $links;
+	}
+
+	/**
+	 * Creates the menu items for FB Instant Article in WordPress side menu.
+	 *
+	 * @since 0.4
+	 */
+	public static function menu_items() {
+		add_menu_page(
+			'Instant Articles Settings',
+			'Facebook<br />Instant Articles',
+			'manage_options',
+			self::IA_PLUGIN_SETTINGS_SLUG,
+			array( 'Instant_Articles_Settings', 'render_settings_page' )
+			,'dashicons-thumbs-up'
+		);
+	}
+
+	/**
+	 * Optains the state for current step from state-machine.
+	 *
+	 * @param int $step_id The step identifier.
+	 * @since 0.4
+	 */
+	public static function get_state_for_wizard_step( $step_id ) {
+		$fb_page_settings = Instant_Articles_Option_FB_Page::get_option_decoded();
+
+		switch ( $step_id ) {
+			case 'app-id':
+				if ( isset( $fb_page_settings['app_id'] ) && isset( $fb_page_settings['app_secret'] ) ) {
+					return '';
+				} else {
+					return 'current';
+				}
+				break;
+
+			case 'page-id':
+				if ( isset( $fb_page_settings['page_id'] ) && isset( $fb_page_settings['page_access_token'] ) ) {
+					return '';
+				} else {
+					return 'current';
+				}
+				break;
+
+			default:
+				# code...
+				break;
+		}
+	}
+
+	/**
+	 *
+	 *
+	 * @since 0.4
+	 */
+	public static function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html( 'You do not have sufficient permissions to access this page.' ) );
+		}
+
+		settings_errors();
+
+		$fb_page_settings = Instant_Articles_Option_FB_Page::get_option_decoded();
+
+		if ( isset( $fb_page_settings['page_id'] ) && ! empty( $fb_page_settings['page_id'] ) ) {
+
+			$claim_url_href = add_query_arg(
+				array(
+					'section' => 'claim-url',
+					'url-placeholder' => wp_parse_url( site_url(), PHP_URL_HOST ),
+				),
+				'https://www.facebook.com/' . $fb_page_settings['page_id'] . '/settings/?tab=instant_articles'
+			);
+
+		}
+
+		if ( filter_input( INPUT_GET, 'current_tab' ) ) {
+			$tab = filter_input( INPUT_GET, 'current_tab' );
+		} else {
+			$tab = 'basic';
+		}
+
+		$settings_page_href = self::get_href_to_settings_page();
+
+		include( dirname( __FILE__ ) . '/template-settings.php' );
+	}
+}

--- a/settings/template-settings-advanced.php
+++ b/settings/template-settings-advanced.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+ ?>
+<form method="post" action="options.php">
+<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP ); ?>
+<?php do_settings_sections( Instant_Articles_Option_Analytics::OPTION_KEY ); ?>
+<hr />
+<?php do_settings_sections( Instant_Articles_Option_Ads::OPTION_KEY ); ?>
+<hr />
+<?php do_settings_sections( Instant_Articles_Option_Publishing::OPTION_KEY ); ?>
+<hr />
+<?php submit_button( __( 'Save changes' ) ); ?>
+</form>

--- a/settings/template-settings-wizard.php
+++ b/settings/template-settings-wizard.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+  if ( Instant_Articles_Settings_Wizard::get_current_step_id() === 'next-steps' ) : ?>
+
+	<h2>Initial Setup Complete</h2>
+
+	<h4 class="dashicons-before dashicons-facebook">
+		Your Instant Articles will be published to:
+		<a href="http://facebook.com/<?php echo absint( $fb_page_settings['page_id'] ); ?>" target="_blank">
+			<?php echo esc_html( $fb_page_settings['page_name'] ); ?>
+		</a>.
+	</h4>
+
+	<form method="post" action="options.php">
+		<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
+		<?php submit_button( __( 'Reconfigure' ) ); ?>
+	</form>
+
+	<hr>
+
+	<p>
+		You're all set up!
+	<p>
+		To begin publishing into Instant Articles, proceed to any post
+		and you'll see more information regarding it's published status.
+	</p>
+
+	<p>
+		Existing posts will only be published if you re-save it.
+	</p>
+
+	<h4>Next steps:</h4>
+
+	<ol>
+		<li>Configure styles (<a href="https://developers.facebook.com/docs/instant-articles/guides/design">more info</a>)</li>
+		<li>Signup for notifications</li>
+		<li>Submit articles for review</li>
+	</ol>
+
+<?php else : ?>
+
+	<div class="instant-articles-wizard-container">
+
+		<ol class="instant-articles-wizard-steps">
+
+			<!-- Wizard Step: ia-signup -->
+			<li
+				data-step-id="ia-signup"
+				class="<?php echo esc_attr( Instant_Articles_Settings_Wizard::get_state_for_step( 'ia-signup' ) ) ?>">
+
+				<h3>Sign up for Instant Articles</h3>
+
+				<div class="step-details">
+					<p>
+						This step needs to be done within Facebook. Here's a
+						<a href="https://facebook.com/instant_articles/signup" target="_blank">link</a>.
+					</p>
+
+					<form method="post" action="options.php">
+						<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
+						<input type="hidden" name="instant-articles-option-wizard[sign_up]" value="true">
+						<?php submit_button( __( 'Next' ) ); ?>
+					</form>
+				</div>
+
+			</li>
+
+
+			<!-- Wizard Step: app-setup -->
+			<li
+				data-step-id="app-setup"
+				class="<?php echo esc_attr( Instant_Articles_Settings_Wizard::get_state_for_step( 'app-setup' ) ) ?>">
+
+				<h3>Set up your Facebook App</h3>
+				<div class="step-details">
+
+					<form method="post" action="options.php">
+						<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
+
+						<p>
+							Your Instant Articles need to be published to a specific Facebook Page through
+							<a href="https://developers.facebook.com/apps/">an existing</a>
+							Facebook App:
+						</p>
+
+						<?php do_settings_sections( Instant_Articles_Option_Wizard::OPTION_KEY ); ?>
+						<?php do_settings_sections( Instant_Articles_Option_FB_App::OPTION_KEY ); ?>
+
+						<?php submit_button( __( 'Next' ) ); ?>
+					</form>
+
+				</div>
+			</li>
+
+
+
+
+			<!-- Wizard Step: page-selection -->
+			<li
+				data-step-id="page-selection"
+				class="<?php
+					echo esc_attr ( Instant_Articles_Settings_Wizard::get_state_for_step( 'page-selection' ) );
+				?>"
+			>
+				<h3>Facebook Page</h3>
+				<div class="step-details">
+
+					<form method="post" action="options.php">
+						<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
+						<?php do_settings_sections( Instant_Articles_Option_Wizard::OPTION_KEY ); ?>
+						<?php do_settings_sections( Instant_Articles_Option_FB_Page::OPTION_KEY ); ?>
+						<div style="display: none">
+							<?php do_settings_sections( Instant_Articles_Option_FB_App::OPTION_KEY ); ?>
+						</div>
+
+						<?php
+						$fb_helper = new Instant_Articles_Settings_FB_Page();
+						$access_token = $fb_helper->get_fb_access_token();
+						$permissions = $fb_helper->get_fb_permissions( $access_token );
+						?>
+
+						<?php if ( ! $access_token ) : ?>
+
+							<script>
+								//*
+								function loginCallback2(response) {
+									if (response.status === 'connected') {
+										location.reload();
+										//probably good to do an ajax call to a login_callback page
+									} else if (response.status === 'not_authorized') {
+										// The person is logged into Facebook, but not your app.
+									} else {
+										// The person is not logged into Facebook, so we're not sure if
+										// they are logged into this app or not.
+									}
+								}
+								//*/
+							</script>
+
+							<div
+								class="fb-login-button"
+								data-size="medium"
+								data-scope="<?php
+									echo esc_html(
+										implode( Instant_Articles_Settings_FB_Page::$fb_app_permissions, ',' )
+									);
+								?>"
+								onlogin="loginCallback2">
+								List Pages
+							</div>
+
+						<?php
+						elseif (
+							( ! isset( $permissions['pages_manage_instant_articles'] )  ) ||
+							( ! isset( $permissions['pages_show_list'] ) )
+						) :
+						?>
+
+							<script>
+								//*
+								function loginCallback2(response) {
+									if (response.status === 'connected') {
+										location.reload();
+										//probably good to do an ajax call to a login_callback page
+									} else if (response.status === 'not_authorized') {
+										// The person is logged into Facebook, but not your app.
+									} else {
+										// The person is not logged into Facebook, so we're not sure if
+										// they are logged into this app or not.
+									}
+								}
+								//*/
+							</script>
+
+							<p>In order to finish the setup, you need to grant these permissions:</p>
+							<ul>
+								<?php if ( ! isset( $permissions['pages_show_list'] ) ) : ?>
+									<li>
+										<b>pages_show_list</b>: allows us to show the list of your
+										pages for you to pick one.
+									</li>
+								<?php endif; ?>
+								<?php if ( ! isset( $permissions['pages_manage_instant_articles'] ) ) : ?>
+									<li>
+										<b>pages_manage_instant_articles</b>: allows us to publish
+										Instant Articles to your page.
+									</li>
+								<?php endif; ?>
+							</p>
+
+							<p>Please grant the needed permissions to continue:</p>
+
+							<div
+								class="fb-login-button"
+								data-size="medium"
+								data-scope="<?php
+									echo esc_attr(
+										implode( Instant_Articles_Settings_FB_Page::$fb_app_permissions, ',' )
+									);
+								?>"
+								onlogin="loginCallback2">
+								Grant needed permissions
+							</div>
+
+						<?php else : ?>
+
+							<table class="form-table">
+								<tr>
+									<th scope="row">
+										Facebook Page
+									</th>
+									<td>
+										<?php
+										$helper = new Facebook\InstantArticles\Client\Helper(
+											$fb_helper->fb_sdk
+										);
+
+										$fb_page_settings = Instant_Articles_Option_FB_Page::get_option_decoded();
+
+										// Map GraphNode objects to simple value objects that are smaller when serialized.
+										$pages_and_tokens = array_map(function( $page_node ) {
+											return (object) [
+												'page_id' => $page_node->getField( 'id' ),
+												'page_name' => $page_node->getField( 'name' ),
+												'page_access_token' => $page_node->getField( 'access_token' ),
+											];
+										}, $helper->getPagesAndTokens( $access_token )->all());
+
+										?>
+										<select id="<?php echo esc_attr( 'instant-articles-fb-page-selector' ) ?>">
+											<option value="" disabled selected>Select your Page</option>
+											<?php foreach ( $pages_and_tokens as $page ) : ?>
+												<option value="<?php echo esc_attr( json_encode( $page ) ) ?>">
+													<?php echo esc_html( $page->page_name ) ?>
+												</option>
+											<?php endforeach; ?>
+										</select>
+									</td>
+								</tr>
+							</table>
+							<?php submit_button( __( 'Next' ) ); ?>
+						<?php endif; ?>
+					</form>
+				</div>
+			</li>
+
+
+			<!-- Wizard Step: claim-url -->
+			<li
+				data-step-id="claim-url"
+				class="<?php echo esc_attr( Instant_Articles_Settings_Wizard::get_state_for_step( 'claim-url' ) ) ?>"
+			>
+
+				<h3>Claim URLs</h3>
+				<div class="step-details">
+					<p>
+						Claim your URLs <a target="_blank" href="<?php echo esc_attr( $claim_url_href ) ?>">here</a>.
+						We think the one for this Wordpress site is:
+						<strong><code><?php echo esc_html( site_url() ); ?></code></strong>.
+					</p>
+
+					<form method="post" action="options.php">
+						<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
+						<div style="display: none">
+							<?php do_settings_sections( Instant_Articles_Option_Wizard::OPTION_KEY ); ?>
+							<?php do_settings_sections( Instant_Articles_Option_FB_Page::OPTION_KEY ); ?>
+							<?php do_settings_sections( Instant_Articles_Option_FB_App::OPTION_KEY ); ?>
+						</div>
+
+						<input type="hidden" name="instant-articles-option-wizard[claimed_url]" value="true">
+						<?php submit_button( __( 'Done' ) ); ?>
+					</form>
+				</div>
+
+			</li>
+		</ol>
+
+		<hr>
+
+		<?php if ( Instant_Articles_Settings_Wizard::get_current_step_id() !== 'ia-signup' ) : ?>
+			<form method="post" action="options.php" id="instant-articles-restart-wizard">
+				<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
+				<?php submit_button( __( 'Restart Wizard' ), 'secondary' ); ?>
+			</form>
+		<?php endif; ?>
+
+	</div>
+
+<?php endif;

--- a/settings/template-settings.php
+++ b/settings/template-settings.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+?>
+<div class="wrap">
+	<h1>Facebook Instant Articles Settings</h1>
+
+	<h2 id="instant-articles-settings-tabs" class="nav-tab-wrapper">
+		<a
+			class="nav-tab <?php if ( 'basic' === $tab ) : ?>nav-tab-active<?php endif; ?>"
+			href="<?php echo esc_attr( $settings_page_href . '&current_tab=basic' ) ?>"
+		>
+			Initial Setup
+		</a>
+		<a
+			class="nav-tab <?php if ( 'advanced' === $tab ) : ?>nav-tab-active<?php endif; ?>"
+			href="<?php echo esc_attr( $settings_page_href . '&current_tab=advanced' ) ?>"
+		>
+			Advanced
+		</a>
+	</h2>
+
+	<div
+		id="instant-articles-settings-basic"
+		<?php if ( 'basic' !== $tab ) : ?>style="display: none;"<?php endif; ?>
+	>
+		<?php include( dirname( __FILE__ ) . '/template-settings-wizard.php' ); ?>
+	</div>
+	<div
+		id="instant-articles-settings-advanced"
+		<?php if ( 'advanced' !== $tab ) : ?>style="display: none;"<?php endif; ?>
+	>
+		<?php include( dirname( __FILE__ ) . '/template-settings-advanced.php' ); ?>
+	</div>
+</div>

--- a/template.php
+++ b/template.php
@@ -8,12 +8,12 @@
 
 		<?php
 		/**
-         * Fires in the head element of each article
-         *
-         * @since 0.1
-         *
-         * @param Instant_Articles_Post  $ia_post  The current article object
-         */
+		 * Fires in the head element of each article
+		 *
+		 * @since 0.1
+		 *
+		 * @param Instant_Articles_Post  $ia_post  The current article object
+		 */
 		do_action( 'instant_articles_article_head', $this );
 		?>
 	</head>
@@ -89,7 +89,7 @@
 
 				<?php if ( $kicker_text = $this->get_the_kicker() ) : ?>
 					<!-- A kicker for your article -->
-					<h3 class="op-kicker"><?php echo esc_html( $kicker_text); ?></h3>
+					<h3 class="op-kicker"><?php echo esc_html( $kicker_text ); ?></h3>
 				<?php endif; ?>
 
 				<?php
@@ -116,7 +116,7 @@
 
 				<?php if ( $footer_copyright = $this->get_the_footer_copyright( ) ) : ?>
 					<!-- Copyright details for your article -->
-					<small><?php echo esc_html ( $footer_copyright ); ?></small>
+					<small><?php echo esc_html( $footer_copyright ); ?></small>
 				<?php endif; ?>
 			</footer>
 		</article>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {

--- a/tests/test-class-instant-articles-post.php
+++ b/tests/test-class-instant-articles-post.php
@@ -1,50 +1,56 @@
 <?php
 /**
- * Test class responsible for constructing article content 
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( './class-instant-articles-post.php' );
+
+/**
+ * Test class responsible for constructing article content
  *
  * @since 0.1
  */
-
-require_once('./class-instant-articles-post.php');
-
 class InstantArticlesPost extends WP_UnitTestCase {
 
 	protected $post_id;
 
 	public function setup() {
 		$user_id = $this->factory->user->create();
-		$this->post_id = $this->factory->post->create( array( 
-			'post_author' => $user_id , 
-			'post_title' => 'Article title', 
+		$this->post_id = $this->factory->post->create( array(
+			'post_author' => $user_id,
+			'post_title' => 'Article title',
 			'post_content' => 'something',
-				'post_excerpt' => 'This is the excerpt.',
-				'post_date' => '',
-				'post_modified' => ''
-			) 
+			'post_excerpt' => 'This is the excerpt.',
+			'post_date' => '',
+			'post_modified' => '',
+			)
 		);
-		$this->instant_articles_post =  new Instant_Articles_Post( $this->post_id );
+		$this->instant_articles_post = new Instant_Articles_Post( $this->post_id );
 	}
 
-	public function testCreateInstance()
-	{
-			$this->assertInstanceOf('Instant_Articles_Post', $this->instant_articles_post);
-	} 
+	public function testCreateInstance() {
 
-	public function testGetPostFields()
-	{
-		$this->assertEquals('Article title', $this->instant_articles_post->get_the_title() );
-		$this->assertEquals('Article title',  $this->instant_articles_post->get_the_title_rss() );
-		$this->assertEquals('http://viptests.dev/?p='.$this->post_id,  $this->instant_articles_post->get_canonical_url() );
-		$this->assertTrue(is_string( $this->instant_articles_post->get_the_excerpt() ), 'Expected string assertion failed.');
-		$this->assertTrue(is_string( $this->instant_articles_post->get_the_excerpt_rss() ), 'Expected string assertion failed.');
-	} 
+			$this->assertInstanceOf( 'Instant_Articles_Post', $this->instant_articles_post );
+	}
+
+	public function testGetPostFields() {
+
+		$this->assertEquals( 'Article title', $this->instant_articles_post->get_the_title() );
+		$this->assertEquals( 'Article title',  $this->instant_articles_post->get_the_title_rss() );
+		$this->assertEquals( 'http://viptests.dev/?p=' . $this->post_id,  $this->instant_articles_post->get_canonical_url() );
+		$this->assertTrue( is_string( $this->instant_articles_post->get_the_excerpt() ), 'Expected string assertion failed.' );
+		$this->assertTrue( is_string( $this->instant_articles_post->get_the_excerpt_rss() ), 'Expected string assertion failed.' );
+	}
 
 	public function testGetFeaturedImage_NoImage_HasArray() {
-		$this->assertTrue( is_array( $this->instant_articles_post->get_the_featured_image() ) ); 
+		$this->assertTrue( is_array( $this->instant_articles_post->get_the_featured_image() ) );
 	}
 
 	public function testGetTheKicker_NoCategory() {
-		$this->assertEmpty( $this->instant_articles_post->get_the_kicker() ); 
+		$this->assertEmpty( $this->instant_articles_post->get_the_kicker() );
 	}
-
 }

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -1,22 +1,29 @@
 <?php
 /**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( './shortcodes.php' );
+
+/**
  * Test class responsible for short code output
  *
  * @since 0.1
  */
-require_once('./shortcodes.php');
-
 class Shortcodes extends WP_UnitTestCase {
 
-	public function testShortCodeHandlerAudio()
-    {
-    	$input = array( 'mp3' => 'http://my.site/music.mp3');
+	public function testShortCodeHandlerAudio() {
 
-    	$expected = '<figure><audio title="music.mp3"><source src="http://my.site/music.mp3"></audio></figure>';
+		$input = array( 'mp3' => 'http://my.site/music.mp3' );
 
-    	$output = instant_articles_shortcode_handler_audio( $input );
+		$expected = '<figure><audio title="music.mp3"><source src="http://my.site/music.mp3"></audio></figure>';
 
-       	$this->assertEquals( $expected, $output );
-    } 
+		$output = instant_articles_shortcode_handler_audio( $input );
 
+	   	$this->assertEquals( $expected, $output );
+	}
 }


### PR DESCRIPTION
This pull request intends to replace the existing transformation engine of the plugin with the Facebook Instant Articles PHP SDK's Transformer engine.

I did include the SDK as a composer dependency instead of bundling the SDK.

The new structure expect rules to be configured within the `rules-configuration.json` file.