### PR TITLE
Ensure that Related Articles are not stripped

### DIFF
--- a/dom-transform-filters/class-instant-articles-dom-transform-filter-emptyelements.php
+++ b/dom-transform-filters/class-instant-articles-dom-transform-filter-emptyelements.php
@@ -106,7 +106,7 @@ class Instant_Articles_DOM_Transform_Filter_Emptyelements extends Instant_Articl
 	 */
 	public function run() {
 
-		
+
 		$xpathQuery = '//' . implode( ' | //', $this->_checkTagNames );;
 
 		$xpath = new DOMXpath( $this->_DOMDocument );
@@ -141,7 +141,7 @@ class Instant_Articles_DOM_Transform_Filter_Emptyelements extends Instant_Articl
 			// Climb up to make sure we’re not in an Instant Article element (which should have proper handling elsewhere)
 			$parentNode = $DOMNode;
 			while ( isset( $parentNode->nodeName ) && $parentNode->nodeName != 'body' ) {
-				if ( 'figure' == $parentNode->nodeName && false !== strpos( $parentNode->getAttribute( 'class' ), 'op-' ) ) {
+				if ( ( 'figure' == $parentNode->nodeName || 'ul' == $parentNode->nodeName ) && false !== strpos( $parentNode->getAttribute( 'class' ), 'op-' ) ) {
 					// We found an element that’s likely to be an Instant Article element
 					continue 2;
 				}
@@ -154,7 +154,7 @@ class Instant_Articles_DOM_Transform_Filter_Emptyelements extends Instant_Articl
 				$this->_filter_empty_elements( $DOMNode->childNodes );
 			}
 
-			
+
 			if ( isset( $DOMNode->nodeValue ) && '' == trim( $DOMNode->nodeValue ) ) {
 
 				if ( ! isset( $DOMNode->childNodes ) || is_null( $DOMNode->childNodes ) || ( is_a( $DOMNode->childNodes, 'DOMNodeList' ) && ! $DOMNode->childNodes->length ) ) {
@@ -203,5 +203,3 @@ class Instant_Articles_DOM_Transform_Filter_Emptyelements extends Instant_Articl
 
 
 }
-
-

--- a/dom-transform-filters/class-instant-articles-dom-transform-filter-unordered-list.php
+++ b/dom-transform-filters/class-instant-articles-dom-transform-filter-unordered-list.php
@@ -37,7 +37,9 @@ class Instant_Articles_DOM_Transform_Filter_Unordered_List extends Instant_Artic
 	 */
 	protected function _transform_element( DOMNode $DOMNode ) {
 		if ( false === strpos( $DOMNode->getAttribute( 'class' ), 'op-' ) ) {
-			parent::_transform_element( $DOMNode );
+			return parent::_transform_element( $DOMNode );
+		} else {
+			return $DOMNode;
 		}
 	}
 

--- a/dom-transform-filters/class-instant-articles-dom-transform-filter-unordered-list.php
+++ b/dom-transform-filters/class-instant-articles-dom-transform-filter-unordered-list.php
@@ -37,12 +37,7 @@ class Instant_Articles_DOM_Transform_Filter_Unordered_List extends Instant_Artic
 	 */
 	protected function _transform_element( DOMNode $DOMNode ) {
 		if ( false === strpos( $DOMNode->getAttribute( 'class' ), 'op-' ) ) {
-			// Ensure that the Instant Article Element retain their class.
-			$original_node = $DOMNode;
-			$DOMNode = parent::_transform_element( $DOMNode );
-			$DOMNode->setAttribute( 'class', $original_node->getAttribute( 'class' ) );
-		} else {
-			return $DOMNode;
+			parent::_transform_element( $DOMNode );
 		}
 	}
 

--- a/dom-transform-filters/class-instant-articles-dom-transform-filter-unordered-list.php
+++ b/dom-transform-filters/class-instant-articles-dom-transform-filter-unordered-list.php
@@ -27,6 +27,26 @@ class Instant_Articles_DOM_Transform_Filter_Unordered_List extends Instant_Artic
 	}
 
 	/**
+	 * Transform an element
+	 *
+	 * Overlay the parent {@see Instant_Articles_DOM_Transform_Filter::_transform_element}
+	 * method by checking for the Instant Article class and preserving it.
+	 *
+	 * @param DOMNode  $DOMNode  The original DOM node
+	 * @return DOMNode  The tranformed DOMNode. If you want to chain.
+	 */
+	protected function _transform_element( DOMNode $DOMNode ) {
+		if ( false === strpos( $DOMNode->getAttribute( 'class' ), 'op-' ) ) {
+			// Ensure that the Instant Article Element retain their class.
+			$original_node = $DOMNode;
+			$DOMNode = parent::_transform_element( $DOMNode );
+			$DOMNode->setAttribute( 'class', $original_node->getAttribute( 'class' ) );
+		} else {
+			return $DOMNode;
+		}
+	}
+
+	/**
 	 * Build a DOMDocumentFragment for the element
 	 *
 	 * @since 0.1
@@ -40,7 +60,7 @@ class Instant_Articles_DOM_Transform_Filter_Unordered_List extends Instant_Artic
 		for ( $i = 0; $i < $properties->childNodes->length; ++$i ) {
 			$ul->appendChild( $properties->childNodes->item( $i ) );
 		}
-		
+
 		$DOMDocumentFragment->appendChild( $ul );
 
 		return $DOMDocumentFragment;


### PR DESCRIPTION
Allow the `<ul>` element to be empty for Related Articles: https://developers.facebook.com/docs/instant-articles/reference/related-articles

Ensure that `<ul>` elements with a Instant Article class keep their classes and that they are not emptied.

This can probably be done a better way to filter the element and still keep the class attached.