### PR TITLE
Update template-settings-info.php

### DIFF
--- a/settings/template-settings-info.php
+++ b/settings/template-settings-info.php
@@ -12,7 +12,7 @@
 </p>
 <ol>
 	<li><a href="https://www.facebook.com/instant_articles/signup" target="_blank">Sign up</a> for Instant Articles, if you haven't already, and come back to activate the plugin using the page you enabled.
-	<li>Claim the URL you will use to publish articles. Right now, we think the URL you will use to publish to this Page is: <code><?php echo esc_url(site_url()); ?></code>.
+	<li>Claim the URL you will use to publish articles. Right now, we think the URL you will use to publish to this Page is: <code><?php echo esc_url(home_url()); ?></code>.
 		<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty ( $fb_page_settings['page_id'] ) ) : ?>
 			Claim your URL
 			<a


### PR DESCRIPTION
https://codex.wordpress.org/Function_Reference/site_url
    The site_url template tag retrieves the site url for the current site (where the WordPress core files reside) 

Incase you're moved the Wordpress core files to its own directory,  Wordpress will suggest that you use `http://[your-domain]/[your-wp-core-files-dir]` instead of `http://[your-domain]/`.

I think to use `home_url()` instead is a better way in this scenario.
