### PR TITLE
Stop publishing drafts

### DIFF
--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -37,6 +37,11 @@ class Instant_Articles_Publisher {
 			return;
 		}
 
+		// Don't process if this post is not published
+		if ('publish' !== $post->post_status) {
+			return;
+		}
+
 		// Transform the post to an Instant Article.
 		$adapter = new Instant_Articles_Post( $post );
 		$article = $adapter->to_instant_article();
@@ -68,7 +73,7 @@ class Instant_Articles_Publisher {
 					$take_live = false;
 				} else {
 					// Any publish status other than 'publish' means draft for the Instant Article.
-					$take_live = 'publish' === $post->post_status;
+					$take_live = true;
 				}
 
 				try {

--- a/meta-box/class-instant-articles-meta-box.php
+++ b/meta-box/class-instant-articles-meta-box.php
@@ -62,6 +62,7 @@ class Instant_Articles_Meta_Box {
 		$article = $adapter->to_instant_article();
 		$canonical_url = $adapter->get_canonical_url();
 		$submission_status = null;
+		$published = 'publish' === $post->post_status;
 
 		Instant_Articles_Settings::menu_items();
 		$settings_page_href = Instant_Articles_Settings::get_href_to_settings_page();

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -15,7 +15,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-media-document"></span>
-		Your article will be submitted to Instant Articles once you publish it.
+		Your post will be submitted to Instant Articles once you publish it.
 	</b>
 </p>
 

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -11,8 +11,15 @@ use Facebook\InstantArticles\Client\InstantArticleStatus;
 use Facebook\InstantArticles\Client\ServerMessage;
 ?>
 
-<!-- Submission status -->
-<?php if ( $submission_status ) : ?>
+<?php if ( ! $published ) : ?>
+<p>
+	<b>
+		<span class="dashicons dashicons-media-document"></span>
+		Your article will be submitted to Instant Articles once you publish it.
+	</b>
+</p>
+
+<?php elseif ( $submission_status ) : ?>
 
 	<!-- Display the last submission status -->
 	<?php switch ( $submission_status->getStatus() ) :


### PR DESCRIPTION
We decided to drop the feature where we submit drafts as drafts to Instant Articles. 

The feedback from community is that this behaviour is unexpected and that their libraries got polluted.