### PR TITLE
Fixed empty link to Instant Articles signup

### DIFF
--- a/settings/template-settings-info.php
+++ b/settings/template-settings-info.php
@@ -20,7 +20,12 @@
 		<?php endif; ?>
 	<li>Install the Pages Manager app to preview your articles and styles on <a href="http://itunes.apple.com/app/facebook-pages-manager/id514643583?ls=1&mt=8&ign-mscache=1" target="_blank">iOS</a> or <a href="https://play.google.com/store/apps/details?id=com.facebook.pages.app" target="_blank">Android</a>.
 	<li>Create a style template for your articles, using the Style Editor. Be sure to provide the name of the template you want to use in the Plugin Configuration settings below.
-	<li>[Optional] Enable Audience Network, if you choose. Learn more about <a href="https://fbinstantarticles.files.wordpress.com/2016/03/audience-network_wp_instant-articles-2-2-web_self-serve.pdf" target="_blank">Audience Network</a> for Instant Articles and <a href="" target="_blank">sign up here</a>.
+	<li>[Optional] Enable Audience Network, if you choose. Learn more about <a href="https://fbinstantarticles.files.wordpress.com/2016/03/audience-network_wp_instant-articles-2-2-web_self-serve.pdf" target="_blank">Audience Network</a> for Instant Articles.
+		<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty ( $fb_page_settings['page_id'] ) ) : ?>
+			Sign up for Audience Network
+			<a
+				href="https://www.facebook.com/<?php echo esc_attr( $fb_page_settings['page_id'] ); ?>/settings/?tab=instant_articles#Audience-Network" target="_blank">here</a>.
+		<?php endif; ?>
 	<li>[Optional] Set up your ads and analytics, including Audience Network, in the Configuration area, below.
 	<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty ( $fb_page_settings['page_id'] ) ) : ?>
 		<li>


### PR DESCRIPTION
The link was actually empty. This PR adds the link with in a condition for when a Page ID has been defined.