### PR TITLE
Prevents <figcaptions> from being added to images that were not saved with captions

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -88,16 +88,6 @@
             }
         }
     }, {
-        "class": "CaptionRule",
-        "selector": "img",
-        "properties": {
-            "caption.default": {
-                "type": "string",
-                "selector": "img",
-                "attribute": "alt"
-            }
-        }
-    }, {
         "class": "ListItemRule",
         "selector" : "li"
     }, {


### PR DESCRIPTION
This removes the rule:
```
{
    "class": "CaptionRule",
    "selector": "img",
    "properties": {
        "caption.default": {
            "type": "string",
            "selector": "img",
            "attribute": "alt"
        }
    }
}
```
from `rules-configuration.json`. This rule forces all images to have captions, using the image's `alt` tag as the text. The is undesirable, as the alt text may not be what they user would want for the caption. By removing the rule, this prevents this behavior from occurring.

Fixes #153 