### PR TITLE
Support <mark> tag

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -17,6 +17,9 @@
     },{
         "class": "PassThroughRule",
         "selector" : "del"
+    },{
+        "class": "PassThroughRule",
+        "selector" : "mark"
     }, {
         "class": "PassThroughRule",
         "selector" : "span"


### PR DESCRIPTION
This PR will prevent content within the `<mark>` tag from being stripped. Refer to issue: https://github.com/Automattic/facebook-instant-articles-wp/issues/240