### PR TITLE
Fix scheduled posts with empty IA content

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -290,10 +290,6 @@ class Instant_Articles_Post {
 
 		global $post, $more;
 
-		if ( ! $post ) {
-			return '';
-		}
-
 		// Force $more.
 		$orig_more = $more;
 		$more = 1;


### PR DESCRIPTION
This PR is to avoid scheduled posts ending up as empty Instant Articles as per issue [#198](https://github.com/Automattic/facebook-instant-articles-wp/issues/198).
The removed check seems to be unnecessary, since a smarter check is done right after more gracefully.