### PR TITLE
Width and Height for Interactive in default rules

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -126,6 +126,16 @@
                 "selector" : "iframe",
                 "attribute": "src"
             },
+            "socialembed.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
+            },
+            "socialembed.height" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "height"
+            },
             "socialembed.iframe" : {
                 "type" : "children",
                 "selector" : "iframe"
@@ -143,6 +153,16 @@
                 "type" : "string",
                 "selector" : "iframe",
                 "attribute": "src"
+            },
+            "socialembed.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
+            },
+            "socialembed.height" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "height"
             },
             "socialembed.iframe" : {
                 "type" : "children",
@@ -179,6 +199,16 @@
                 "type" : "string",
                 "selector" : "iframe",
                 "attribute": "src"
+            },
+            "socialembed.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
+            },
+            "socialembed.height" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "height"
             }
         }
     }, {


### PR DESCRIPTION
This PR updates the default rules to use`interactive.width` and `interactive.height`.

Fixes #256, fixes #304.
Follows #342.
Follows facebook/facebook-instant-articles-sdk-php#100.