### PR TITLE
Escape ampersands before displaying on settings page

### DIFF
--- a/settings/class-instant-articles-option-ads.php
+++ b/settings/class-instant-articles-option-ads.php
@@ -219,7 +219,7 @@ class Instant_Articles_Option_Ads extends Instant_Articles_Option {
 					if ( isset( $field_values['ad_source'] ) && 'embed' === $field_values['ad_source'] ) {
 						$document = new DOMDocument();
 						$fragment = $document->createDocumentFragment();
-						$field_values[ $field_id ] = str_replace( '&', '&amp;', $field_values[ $field_id ] );
+						$field_values[ $field_id ] = preg_replace( '/&(?!amp;)/', '&amp;', $field_values[ $field_id ] );
 						if ( ! @$fragment->appendXML( $field_values[ $field_id ] ) ) {
 							add_settings_error(
 								'embed_code',

--- a/settings/class-instant-articles-option-ads.php
+++ b/settings/class-instant-articles-option-ads.php
@@ -219,6 +219,7 @@ class Instant_Articles_Option_Ads extends Instant_Articles_Option {
 					if ( isset( $field_values['ad_source'] ) && 'embed' === $field_values['ad_source'] ) {
 						$document = new DOMDocument();
 						$fragment = $document->createDocumentFragment();
+						$field_values[ $field_id ] = str_replace( '&', '&amp;', $field_values[ $field_id ] );
 						if ( ! @$fragment->appendXML( $field_values[ $field_id ] ) ) {
 							add_settings_error(
 								'embed_code',

--- a/settings/class-instant-articles-option-ads.php
+++ b/settings/class-instant-articles-option-ads.php
@@ -55,6 +55,7 @@ class Instant_Articles_Option_Ads extends Instant_Articles_Option {
 			'description' => 'Add code to be used for displayed ads in your Instant Articles.',
 			'default' => '',
 			'placeholder' => '<script>...</script>',
+			'double_encode' => true,
 		),
 
 		'dimensions' => array(
@@ -214,7 +215,6 @@ class Instant_Articles_Option_Ads extends Instant_Articles_Option {
 					if ( isset( $field_values['ad_source'] ) && 'embed' === $field_values['ad_source'] ) {
 						$document = new DOMDocument();
 						$fragment = $document->createDocumentFragment();
-						$field_values[ $field_id ] = preg_replace( '/&(?!amp;)/', '&amp;', $field_values[ $field_id ] );
 						if ( ! @$fragment->appendXML( $field_values[ $field_id ] ) ) {
 							add_settings_error(
 								'embed_code',

--- a/settings/class-instant-articles-option-analytics.php
+++ b/settings/class-instant-articles-option-analytics.php
@@ -125,7 +125,7 @@ class Instant_Articles_Option_Analytics extends Instant_Articles_Option {
 					if ( isset( $field_values['embed_code_enabled'] ) && $field_values['embed_code_enabled'] ) {
 						$document = new DOMDocument();
 						$fragment = $document->createDocumentFragment();
-						$field_values[ $field_id ] = str_replace( '&', '&amp;', $field_values[ $field_id ] );
+						$field_values[ $field_id ] = preg_replace( '/&(?!amp;)/', '&amp;', $field_values[ $field_id ] );
 						if ( ! @$fragment->appendXML( $field_values[ $field_id ] ) ) {
 							add_settings_error(
 								'embed_code',

--- a/settings/class-instant-articles-option-analytics.php
+++ b/settings/class-instant-articles-option-analytics.php
@@ -125,6 +125,7 @@ class Instant_Articles_Option_Analytics extends Instant_Articles_Option {
 					if ( isset( $field_values['embed_code_enabled'] ) && $field_values['embed_code_enabled'] ) {
 						$document = new DOMDocument();
 						$fragment = $document->createDocumentFragment();
+						$field_values[ $field_id ] = str_replace( '&', '&amp;', $field_values[ $field_id ] );
 						if ( ! @$fragment->appendXML( $field_values[ $field_id ] ) ) {
 							add_settings_error(
 								'embed_code',

--- a/settings/class-instant-articles-option-analytics.php
+++ b/settings/class-instant-articles-option-analytics.php
@@ -43,6 +43,7 @@ class Instant_Articles_Option_Analytics extends Instant_Articles_Option {
 			'placeholder' => '<script>...</script>',
 			'description' => 'Note: You do not need to include any &lt;op-tracker&gt; tags. The plugin will automatically include them in the article markup.',
 			'default' => '',
+			'double_encode' => true,
 		),
 	);
 
@@ -125,7 +126,6 @@ class Instant_Articles_Option_Analytics extends Instant_Articles_Option {
 					if ( isset( $field_values['embed_code_enabled'] ) && $field_values['embed_code_enabled'] ) {
 						$document = new DOMDocument();
 						$fragment = $document->createDocumentFragment();
-						$field_values[ $field_id ] = preg_replace( '/&(?!amp;)/', '&amp;', $field_values[ $field_id ] );
 						if ( ! @$fragment->appendXML( $field_values[ $field_id ] ) ) {
 							add_settings_error(
 								'embed_code',

--- a/settings/class-instant-articles-option.php
+++ b/settings/class-instant-articles-option.php
@@ -383,7 +383,7 @@ class Instant_Articles_Option {
 					<?php echo esc_attr( $attr_disabled ); ?>
 					class="large-text code"
 					rows="8"
-				><?php echo esc_html( $option_value ); ?></textarea>
+				><?php echo $args[ 'double_encode' ] ? htmlspecialchars( $option_value ) : esc_html( $option_value ); ?></textarea>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
 						<?php echo esc_html( $field_description ); ?>


### PR DESCRIPTION
This PR allows ampersands in the custom embed code for Ads and Analytics, e.g.:
```
<iframe src="http://foo.com?foo&amp;bar"></iframe>
```