### PR TITLE
Disable publishing for custom post types and pages.

### DIFF
--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -37,8 +37,19 @@ class Instant_Articles_Publisher {
 			return;
 		}
 
-		// Don't process custom post types or pages.
-		if ( 'post' !== $post->post_type ) {
+		$post_types = array( 'post' );
+
+		/**
+		 * Filter the allowed post types for publishing instant articles.
+		 *
+		 * @since 2.12
+		 *
+		 * @param array $post_types Array of post types to publish.
+		 */
+		$post_types = apply_filters( 'instant_articles_publisher_post_types', $post_types );
+
+		// Don't process posts not in the allowed post types.
+		if ( ! in_array( $post->post_type, $post_types, true ) ) {
 			return;
 		}
 

--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -37,6 +37,11 @@ class Instant_Articles_Publisher {
 			return;
 		}
 
+		// Don't process custom post types or pages.
+		if ( 'post' !== $post->post_type ) {
+			return;
+		}
+
 		// Don't process if this post is not published
 		if ( 'publish' !== $post->post_status ) {
 			return;


### PR DESCRIPTION
All post types and pages trigger the `save_post` action, but this plugin's post meta box only targets the `post` post type. Publishing other post types and pages goes against expected behavior.

This can be removed if broader support for other post types is implemented as discussed in #186.