### PR TITLE
Remove hyperlinks beginning with a #

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -322,6 +322,12 @@ class Instant_Articles_Post {
 		// Some people choose to disable wpautop. Due to the Instant Articles spec, we really want it in!
 		$content = wpautop( $content );
 
+		// Remove hyperlinks beginning with a # as they cause errors on Facebook (from http://wordpress.stackexchange.com/a/227332/19528)
+	        preg_match_all( '!<a[^>]*? href=[\'"]#[^<]+</a>!i', $content, $matches );
+	        foreach ( $matches[0] as $link ) {
+	                $content = str_replace( $link, strip_tags($link), $content );
+	        }
+		
 		/**
 		 * Filter the post content for Instant Articles.
 		 *


### PR DESCRIPTION
Hyperlinks beginning with a # cause errors on Facebook ("Incorrect URL: Ensure all outbound URL links are valid.")

![anchors](https://cloud.githubusercontent.com/assets/128895/15434880/1e333f3a-1eb1-11e6-942a-84986fe977f2.png)