### PR TITLE
Fix relative URL issue with oembeds not using absolute URLs

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -676,13 +676,17 @@ class Instant_Articles_Post {
 
 		// We need to make sure that scripts use absolute URLs and not relative URLs.
 		$scripts = $document->getElementsByTagName('script');
-		foreach ( $scripts as $script ){
-			if ( ! parse_url( $script, PHP_URL_SCHEME ) ) {
-				$src = $script->getAttribute('src');
-				$script->setAttribute( 'src' , 'https:' . $src );
+		if ( ! empty( $scripts ) ) {
+			foreach ( $scripts as $script ){
+				$src = $script->getAttribute( 'src' );
+				$explode_src = parse_url( $src );
+				if ( is_array( $explode_src ) && empty( $explode_src['scheme'] ) ) {
+					$src = 'https://' . $explode_src['host'] . $explode_src['path'];
+				}
+				$script->setAttribute( 'src' , $src );
 			}
 		}
-		
+
 		libxml_clear_errors();
 		libxml_use_internal_errors( $libxml_previous_state );
 

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -673,6 +673,16 @@ class Instant_Articles_Post {
 		}
 
 		$result = $document->loadHTML( '<!doctype html><html><body>' . $content . '</body></html>' );
+
+		// We need to make sure that scripts use absolute URLs and not just //
+		$scripts = $document->getElementsByTagName('script');
+		foreach ( $scripts as $script ){
+			if ( ! parse_url($script, PHP_URL_SCHEME)) {
+				$src = $script->getAttribute('src');
+				$script->setAttribute( 'src' , 'https:' . $src );
+			}
+		}
+		
 		libxml_clear_errors();
 		libxml_use_internal_errors( $libxml_previous_state );
 

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -674,10 +674,10 @@ class Instant_Articles_Post {
 
 		$result = $document->loadHTML( '<!doctype html><html><body>' . $content . '</body></html>' );
 
-		// We need to make sure that scripts use absolute URLs and not just //
+		// We need to make sure that scripts use absolute URLs and not relative URLs.
 		$scripts = $document->getElementsByTagName('script');
 		foreach ( $scripts as $script ){
-			if ( ! parse_url($script, PHP_URL_SCHEME)) {
+			if ( ! parse_url( $script, PHP_URL_SCHEME ) ) {
 				$src = $script->getAttribute('src');
 				$script->setAttribute( 'src' , 'https:' . $src );
 			}


### PR DESCRIPTION
This fixes an issue when oembeds like instagram, twitter etc. use `<script async="" defer="defer" src="//platform.instagram.com/en_US/embeds.js"/>` instead of `<script async="" defer="defer" src="https://platform.instagram.com/en_US/embeds.js"/>`. Without this fix Facebook Instant Articles will report an error to the user about the article.