### PR TITLE
Added support for multiple ads when using "Embed" option for Ads

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -759,17 +759,26 @@ class Instant_Articles_Post {
 
 			case 'embed':
 				if ( ! empty( $settings_ads['embed_code'] ) ) {
-
-					$document = new DOMDocument();
-					$fragment = $document->createDocumentFragment();
-					$valid_html = @$fragment->appendXML( $settings_ads['embed_code'] );
-
-					if ( $valid_html ) {
-						$ad->withHTML(
-							$fragment
-						);
-						$header->addAd( $ad );
+					$sectionAds = $settings_ads['embed_code'];
+					$tokenizeAds = explode("::", $sectionAds);
+					//print_r($tokenizeAds);
+					
+					foreach ($tokenizeAds as $advert) {
+						$document = new DOMDocument();
+						$fragment = $document->createDocumentFragment();
+						$valid_html = $fragment->appendXML( $advert );
+					
+						if ( $valid_html ) {
+							$ad->withHTML(
+								$fragment
+							);
+							//print_r($ad);
+							$header->addAd( $ad );
+						}					
+					
 					}
+
+
 				}
 				break;
 

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -761,7 +761,6 @@ class Instant_Articles_Post {
 				if ( ! empty( $settings_ads['embed_code'] ) ) {
 					$sectionAds = $settings_ads['embed_code'];
 					$tokenizeAds = explode("::", $sectionAds);
-					//print_r($tokenizeAds);
 					
 					foreach ($tokenizeAds as $advert) {
 						$document = new DOMDocument();

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -760,7 +760,7 @@ class Instant_Articles_Post {
 			case 'embed':
 				if ( ! empty( $settings_ads['embed_code'] ) ) {
 					$sectionAds = $settings_ads['embed_code'];
-					$tokenizeAds = explode("<!-- Embed Ad Block -->", $sectionAds);
+					$tokenizeAds = explode("<!-- adblock -->", $sectionAds);
 					
 					foreach ($tokenizeAds as $advert) {
 						$ad = Ad::create()

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -763,6 +763,10 @@ class Instant_Articles_Post {
 					$tokenizeAds = explode("::", $sectionAds);
 					
 					foreach ($tokenizeAds as $advert) {
+						$ad = Ad::create()
+						->enableDefaultForReuse()
+						->withWidth( $width )
+						->withHeight( $height );
 						$document = new DOMDocument();
 						$fragment = $document->createDocumentFragment();
 						$valid_html = $fragment->appendXML( $advert );


### PR DESCRIPTION
Use "::" as a delimiter between the different ad scripts, even if each ad is a combination of javascript and html.
