### PR TITLE
Clearer message when "article is being processed"

### DIFF
--- a/css/instant-articles-meta-box.css
+++ b/css/instant-articles-meta-box.css
@@ -90,3 +90,8 @@
 	animation: instant_articles_spinner .6s linear infinite;
 	-webkit-animation: instant_articles_spinner .6s linear infinite;
 }
+
+.instant-articles-spin-animation {
+	animation: instant_articles_spinner .6s linear infinite;
+	-webkit-animation: instant_articles_spinner .6s linear infinite;
+}

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -41,11 +41,11 @@ use Facebook\InstantArticles\Client\ServerMessage;
 			</p>
 			<?php break; ?>
 
-		<?php case InstantArticleStatus::IN_PROGRESS : ?>
+		<?php case InstantArticleStatus::IN_PROGRESS : /* Asset Ingestion */ ?>
 			<p>
 				<b>
-					<span class="dashicons dashicons-update"></span>
-					Your article is being submitted...
+					<span class="dashicons dashicons-update instant-articles-spin-animation"></span>
+					Your article is being published to Facebook. Please wait or refresh to update the status...
 				</b>
 			</p>
 			<script>
@@ -53,14 +53,23 @@ use Facebook\InstantArticles\Client\ServerMessage;
 					instant_articles_load_meta_box( <?php echo absint( $post->ID ); ?> );
 				}, 2000);
 			</script>
-
 			<?php break; ?>
 
 		<?php default : ?>
 			<p>
 				<b>
+				<?php if ( $article_id ) : /* Article Processing */ ?>
+					<span class="dashicons dashicons-update instant-articles-spin-animation"></span>
+					Getting the status of your article...
+					<script>
+						setTimeout(function () {
+							instant_articles_load_meta_box( <?php echo absint( $post->ID ); ?> );
+						}, 2000);
+					</script>
+				<?php else : ?>
 					<span class="dashicons dashicons-no-alt"></span>
 					This post was not yet submitted to Instant Articles.
+				<?php endif; ?>
 				</b>
 			</p>
 			<?php break; ?>


### PR DESCRIPTION
This PR:

* [ ] Abstracts away the two "sub-in-progress" statuses for article submission/updates
* [ ] Adds an new "official" status in the `InstantArticleStatus` class of the SDK (such as `InstantArticleStatus::AWAITING_STATUS_GENERATION`
* [x] Differentiates IA status between "article processing" and "asset ingestion" with updated messages
