### PR TITLE
Fixed error message: Deprecated: Non-static method DOMDocument::loadH…

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -614,7 +614,8 @@ class Instant_Articles_Post {
 
 		$title = $this->get_the_title();
 		if ( $title ) {
-			$document = DOMDocument::loadHTML( '<?xml encoding="' . $blog_charset . '" ?><h1>' . $title . '</h1>' );
+			$document = new DOMDocument();
+			$document->loadHTML( '<?xml encoding="' . $blog_charset . '" ?><h1>' . $title . '</h1>' );
 			$transformer->transform( $header, $document );
 		}
 


### PR DESCRIPTION
This PR:

* [x] Fixes deprecated call to static DOMDocument::loadHTML() call.


Fixes #

Fixed error message: Deprecated: Non-static method DOMDocument::loadHTML() should not be called statically in /class-instant-articles-post.php on line 617