### PR TITLE
Fixed statically-called loadHTML()

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -641,7 +641,8 @@ class Instant_Articles_Post {
 		if ( $cover['src'] ) {
 			$image = Image::create()->withURL( $cover['src'] );
 			if ( isset( $cover['caption'] ) && strlen( $cover['caption'] ) > 0 ) {
-				$document = DOMDocument::loadHTML( '<?xml encoding="' . $blog_charset . '" ?><h1>' . $cover['caption']  . '</h1>' );
+				$document = new DOMDocument();
+				$document->loadHTML( '<?xml encoding="' . $blog_charset . '" ?><h1>' . $cover['caption']  . '</h1>' );
 				$image->withCaption( $transformer->transform( Caption::create(), $document ) );
 			}
 


### PR DESCRIPTION
This PR fixes the deprecated call to static DOMDocument::loadHTML() on line 644.

Follows #308.