### PR TITLE
Update Instant_Articles_Post->_get_the_content() to validate $post->I…

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -296,7 +296,8 @@ class Instant_Articles_Post {
 
 		// If we’re not it the loop or otherwise properly setup.
 		$reset_postdata = false;
-		if ( $this->_post->ID !== $post->ID ) {
+
+		if ( empty($post->ID) OR ( $this->_post->ID !== $post->ID ) ) {
 			$post = get_post( $this->_post->ID );
 			setup_postdata( $post );
 			$reset_postdata = true;


### PR DESCRIPTION
Fixes the following error which blocks saving contact forms in Contact Form 7:

`Notice: Trying to get property of a non-object in /.../.../fb-instant-articles/class-instant-articles-post.php on line 299`

Whatever this code is trying to do, I don't think it intends to throw an error when `$post->ID` is empty. 

This edit replicates the old behavior but without throwing a notice:  If `$post` is undefined OR the ID doesn't match `$this->_post` then we run `setup_postdata()` to ensure globals reflect `$this->post_id`. 

The undefined `$post` state was previously implied rather than specified, but I can't see how the old code would behave differently from this edit.