### PR TITLE
Fix whitespace to match WordPress coding standards

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -591,9 +591,9 @@ class Instant_Articles_Post {
 		$settings_publishing = Instant_Articles_Option_Publishing::get_option_decoded();
 
 		if (
-			isset ( $settings_publishing['custom_rules_enabled'] ) &&
+			isset( $settings_publishing['custom_rules_enabled'] ) &&
 			! empty( $settings_publishing['custom_rules_enabled'] ) &&
-			isset ( $settings_publishing['custom_rules'] ) &&
+			isset( $settings_publishing['custom_rules'] ) &&
 			! empty( $settings_publishing['custom_rules'] )
 		) {
 			$transformer->loadRules( $settings_publishing['custom_rules'] );
@@ -655,10 +655,9 @@ class Instant_Articles_Post {
 				->addMetaProperty( 'op:generator:application:version', IA_PLUGIN_VERSION );
 
 		$settings_style = Instant_Articles_Option_Styles::get_option_decoded();
-		if ( isset( $settings_style['article_style'] ) && ! empty ( $settings_style['article_style'] ) ) {
+		if ( isset( $settings_style['article_style'] ) && ! empty( $settings_style['article_style'] ) ) {
 			$this->instant_article->withStyle( $settings_style['article_style'] );
-		}
-		else {
+		} else {
 			$this->instant_article->withStyle( 'default' );
 		}
 

--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -51,7 +51,7 @@ class Instant_Articles_Publisher {
 		// This is important because the save_post action is also triggered by bulk updates, but in this case
 		// WordPress does not load the content field from DB for performance reasons. In this case, articles
 		// will be empty here, despite of them actually having content.
-		if ( count($article->getChildren()) === 0 || ! $article->getHeader() || ! $article->getHeader()->getTitle() ) {
+		if ( count( $article->getChildren() ) === 0 || ! $article->getHeader() || ! $article->getHeader()->getTitle() ) {
 			return;
 		}
 

--- a/compat/class-instant-articles-jetpack.php
+++ b/compat/class-instant-articles-jetpack.php
@@ -39,7 +39,7 @@ class Instant_Articles_Jetpack {
 	private function _fix_facebook_embed() {
 
 		// All of these are registered in jetpack/modules/shortcodes/facebook.php
-		
+
 		if ( defined( 'JETPACK_FACEBOOK_EMBED_REGEX' ) ) {
 			wp_embed_unregister_handler( 'facebook' );
 			wp_embed_register_handler( 'facebook', JETPACK_FACEBOOK_EMBED_REGEX, array( __CLASS__, 'facebook_embed_handler' ) );
@@ -71,14 +71,13 @@ class Instant_Articles_Jetpack {
 		$locale = get_locale();
 
 		// Source: https://www.facebook.com/translations/FacebookLocales.xml
-		$fbLocales = array( 'af_ZA', 'ak_GH', 'am_ET', 'ar_AR', 'as_IN', 'ay_BO', 'az_AZ', 'be_BY', 'bg_BG', 'bn_IN', 'br_FR', 'bs_BA', 'ca_ES', 'cb_IQ', 'ck_US', 'co_FR', 'cs_CZ', 'cx_PH', 'cy_GB', 'da_DK', 'de_DE', 'el_GR', 'en_GB', 'en_IN', 'en_PI', 'en_UD', 'en_US', 'eo_EO', 'es_CL', 'es_CO', 'es_ES', 'es_LA', 'es_MX', 'es_VE', 'et_EE', 'eu_ES', 'fa_IR', 'fb_LT', 'ff_NG', 'fi_FI', 'fo_FO', 'fr_CA', 'fr_FR', 'fy_NL', 'ga_IE', 'gl_ES', 'gn_PY', 'gu_IN', 'gx_GR', 'ha_NG', 'he_IL', 'hi_IN', 'hr_HR', 'ht_HT', 'hu_HU', 'hy_AM', 'id_ID', 'ig_NG', 'is_IS', 'it_IT', 'ja_JP', 'ja_KS', 'jv_ID', 'ka_GE', 'kk_KZ', 'km_KH', 'kn_IN', 'ko_KR', 'ku_TR', 'ky_KG', 'la_VA', 'lg_UG', 'li_NL', 'ln_CD', 'lo_LA', 'lt_LT', 'lv_LV', 'mg_MG', 'mi_NZ', 'mk_MK', 'ml_IN', 'mn_MN', 'mr_IN', 'ms_MY', 'mt_MT', 'my_MM', 'nb_NO', 'nd_ZW', 'ne_NP', 'nl_BE', 'nl_NL', 'nn_NO', 'ny_MW', 'or_IN', 'pa_IN', 'pl_PL', 'ps_AF', 'pt_BR', 'pt_PT', 'qc_GT', 'qu_PE', 'rm_CH', 'ro_RO', 'ru_RU', 'rw_RW', 'sa_IN', 'sc_IT', 'se_NO', 'si_LK', 'sk_SK', 'sl_SI', 'sn_ZW', 'so_SO', 'sq_AL', 'sr_RS', 'sv_SE', 'sw_KE', 'sy_SY', 'sz_PL', 'ta_IN', 'te_IN', 'tg_TJ', 'th_TH', 'tk_TM', 'tl_PH', 'tl_ST', 'tr_TR', 'tt_RU', 'tz_MA', 'uk_UA', 'ur_PK', 'uz_UZ', 'vi_VN', 'wo_SN', 'xh_ZA', 'yi_DE', 'yo_NG', 'zh_CN', 'zh_HK', 'zh_TW', 'zu_ZA', 'zz_TR', );
+		$fbLocales = array( 'af_ZA', 'ak_GH', 'am_ET', 'ar_AR', 'as_IN', 'ay_BO', 'az_AZ', 'be_BY', 'bg_BG', 'bn_IN', 'br_FR', 'bs_BA', 'ca_ES', 'cb_IQ', 'ck_US', 'co_FR', 'cs_CZ', 'cx_PH', 'cy_GB', 'da_DK', 'de_DE', 'el_GR', 'en_GB', 'en_IN', 'en_PI', 'en_UD', 'en_US', 'eo_EO', 'es_CL', 'es_CO', 'es_ES', 'es_LA', 'es_MX', 'es_VE', 'et_EE', 'eu_ES', 'fa_IR', 'fb_LT', 'ff_NG', 'fi_FI', 'fo_FO', 'fr_CA', 'fr_FR', 'fy_NL', 'ga_IE', 'gl_ES', 'gn_PY', 'gu_IN', 'gx_GR', 'ha_NG', 'he_IL', 'hi_IN', 'hr_HR', 'ht_HT', 'hu_HU', 'hy_AM', 'id_ID', 'ig_NG', 'is_IS', 'it_IT', 'ja_JP', 'ja_KS', 'jv_ID', 'ka_GE', 'kk_KZ', 'km_KH', 'kn_IN', 'ko_KR', 'ku_TR', 'ky_KG', 'la_VA', 'lg_UG', 'li_NL', 'ln_CD', 'lo_LA', 'lt_LT', 'lv_LV', 'mg_MG', 'mi_NZ', 'mk_MK', 'ml_IN', 'mn_MN', 'mr_IN', 'ms_MY', 'mt_MT', 'my_MM', 'nb_NO', 'nd_ZW', 'ne_NP', 'nl_BE', 'nl_NL', 'nn_NO', 'ny_MW', 'or_IN', 'pa_IN', 'pl_PL', 'ps_AF', 'pt_BR', 'pt_PT', 'qc_GT', 'qu_PE', 'rm_CH', 'ro_RO', 'ru_RU', 'rw_RW', 'sa_IN', 'sc_IT', 'se_NO', 'si_LK', 'sk_SK', 'sl_SI', 'sn_ZW', 'so_SO', 'sq_AL', 'sr_RS', 'sv_SE', 'sw_KE', 'sy_SY', 'sz_PL', 'ta_IN', 'te_IN', 'tg_TJ', 'th_TH', 'tk_TM', 'tl_PH', 'tl_ST', 'tr_TR', 'tt_RU', 'tz_MA', 'uk_UA', 'ur_PK', 'uz_UZ', 'vi_VN', 'wo_SN', 'xh_ZA', 'yi_DE', 'yo_NG', 'zh_CN', 'zh_HK', 'zh_TW', 'zu_ZA', 'zz_TR' );
 
 		// If our locale isn’t supported by Facebook, we’ll fallback to en_US
-		if ( ! in_array( $locale, $fbLocales) ) {
+		if ( ! in_array( $locale, $fbLocales ) ) {
 			$locale = 'en_US';
 		}
 
 		return '<figure class="op-social"><iframe><script src="//connect.facebook.net/' . $locale . '/sdk.js#xfbml=1&amp;version=v2.2" async></script><div class="fb-post" data-href="' . esc_url( $url ) . '"></div></iframe></figure>';
 	}
-
 }

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -151,11 +151,11 @@ use Facebook\InstantArticles\Client\ServerMessage;
 					<?php echo esc_html( $warning ); ?>
 					<span>
 						<?php
-							if ( $warning->getNode() ) {
-								echo esc_html(
-									$warning->getNode()->ownerDocument->saveHTML( $warning->getNode() )
-								);
-							}
+						if ( $warning->getNode() ) {
+							echo esc_html(
+								$warning->getNode()->ownerDocument->saveHTML( $warning->getNode() )
+							);
+						}
 						?>
 					</span>
 				</div>

--- a/settings/class-instant-articles-option-ads.php
+++ b/settings/class-instant-articles-option-ads.php
@@ -198,7 +198,7 @@ class Instant_Articles_Option_Ads extends Instant_Articles_Option {
 
 				case 'iframe_url':
 					if ( isset( $field_values['ad_source'] ) && 'iframe' === $field_values['ad_source'] ) {
-						$url = $field_values[$field_id];
+						$url = $field_values[ $field_id ];
 						if ( substr( $url, 0, 2 ) === '//' ) {
 							// Allow URLs without protocol prefix
 							$url = 'http:' . $url;

--- a/settings/class-instant-articles-option-publishing.php
+++ b/settings/class-instant-articles-option-publishing.php
@@ -44,7 +44,7 @@ class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
 			'render' => 'textarea',
 			'placeholder' => '{ "rules": [{ "class": "BoldRule", "selector": "span.bold" }, ... ] }',
 			'description' => 'Read more about <a href="https://github.com/facebook/facebook-instant-articles-sdk-php/blob/master/docs/QuickStart.md#custom-transformer-rules" target="_blank">defining your own custom rules</a> to extend/override the <a href="https://github.com/Automattic/facebook-instant-articles-wp/blob/master/rules-configuration.json" target="_blank">built-in ruleset</a>. If you\'ve defined a common rule which you think this plugin should include by default, <a href="https://github.com/Automattic/facebook-instant-articles-wp/issues/new" target="_blank">tell us about it</a>!',
-			'default' => ''
+			'default' => '',
 		),
 
 	);
@@ -62,7 +62,7 @@ class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
 		);
 		wp_localize_script( 'instant-articles-option-publishing', 'INSTANT_ARTICLES_OPTION_PUBLISHING', array(
 			'option_field_id_custom_rules_enabled' => self::OPTION_KEY . '-custom_rules_enabled',
-			'option_field_id_custom_rules'         => self::OPTION_KEY . '-custom_rules'
+			'option_field_id_custom_rules'         => self::OPTION_KEY . '-custom_rules',
 		) );
 	}
 

--- a/settings/class-instant-articles-option.php
+++ b/settings/class-instant-articles-option.php
@@ -176,11 +176,11 @@ class Instant_Articles_Option {
 				array(
 					'a' => array(
 						'href' => array(),
-						'target' => array()
+						'target' => array(),
 					),
 					'em' => array(),
 					'p' => array(),
-					'strong' => array()
+					'strong' => array(),
 				)
 			)
 			: '';
@@ -291,10 +291,10 @@ class Instant_Articles_Option {
 				array(
 					'a' => array(
 						'href' => array(),
-						'target' => array()
+						'target' => array(),
 					),
 					'em' => array(),
-					'strong' => array()
+					'strong' => array(),
 				)
 			)
 			: '';

--- a/settings/class-instant-articles-settings-fb-page.php
+++ b/settings/class-instant-articles-settings-fb-page.php
@@ -24,16 +24,16 @@ class Instant_Articles_Settings_FB_Page implements PersistentDataInterface {
 	/**
 	* @inheritdoc
 	*/
-	public function get( $key )
-	{
+	public function get( $key ) {
+
 		return get_option( $this->session_prefix . $key );
 	}
 
 	/**
 	* @inheritdoc
 	*/
-	public function set( $key, $value )
-	{
+	public function set( $key, $value ) {
+
 		update_option( $this->session_prefix . $key, $value );
 	}
 
@@ -77,7 +77,7 @@ class Instant_Articles_Settings_FB_Page implements PersistentDataInterface {
 				'app_id' => $app_id,
 				'app_secret' => $app_secret,
 				'default_graph_version' => 'v2.5',
-				'persistent_data_handler' => $this
+				'persistent_data_handler' => $this,
 			));
 		}
 	}

--- a/settings/class-instant-articles-settings-wizard.php
+++ b/settings/class-instant-articles-settings-wizard.php
@@ -26,7 +26,7 @@ class Instant_Articles_Settings_Wizard {
 	private static $steps = array(
 		1 => self::STEP_ID_APP_SETUP,
 		2 => self::STEP_ID_PAGE_SELECTION,
-		2 => self::STEP_ID_DONE
+		2 => self::STEP_ID_DONE,
 	);
 
 	/**

--- a/settings/template-settings-advanced.php
+++ b/settings/template-settings-advanced.php
@@ -7,7 +7,7 @@
  * @package default
  */
 
- ?>
+	?>
 <form method="post" action="options.php">
 <?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP ); ?>
 

--- a/settings/template-settings-info.php
+++ b/settings/template-settings-info.php
@@ -6,14 +6,14 @@
  *
  * @package default
  */
- ?>
- <p>
+	?>
+	<p>
 	Once you've activated this WordPress plugin, set up your Instant Articles and submit them to Facebook for a one-time review. The review is required before you can begin publishing. Follow these steps to get started:
 </p>
 <ol>
 	<li><a href="https://www.facebook.com/instant_articles/signup" target="_blank">Sign up</a> for Instant Articles, if you haven't already, and come back to activate the plugin using the page you enabled.
-	<li>Claim the URL you will use to publish articles. Right now, we think the URL you will use to publish to this Page is: <code><?php echo esc_url(home_url()); ?></code>.
-		<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty ( $fb_page_settings['page_id'] ) ) : ?>
+	<li>Claim the URL you will use to publish articles. Right now, we think the URL you will use to publish to this Page is: <code><?php echo esc_url( home_url() ); ?></code>.
+		<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty( $fb_page_settings['page_id'] ) ) : ?>
 			Claim your URL
 			<a
 				href="https://www.facebook.com/<?php echo esc_attr( $fb_page_settings['page_id'] ); ?>/settings/?tab=instant_articles#URL" target="_blank">here</a>.
@@ -21,13 +21,13 @@
 	<li>Install the Pages Manager app to preview your articles and styles on <a href="http://itunes.apple.com/app/facebook-pages-manager/id514643583?ls=1&mt=8&ign-mscache=1" target="_blank">iOS</a> or <a href="https://play.google.com/store/apps/details?id=com.facebook.pages.app" target="_blank">Android</a>.
 	<li>Create a style template for your articles, using the Style Editor. Be sure to provide the name of the template you want to use in the Plugin Configuration settings below.
 	<li>[Optional] Enable Audience Network, if you choose. Learn more about <a href="https://fbinstantarticles.files.wordpress.com/2016/03/audience-network_wp_instant-articles-2-2-web_self-serve.pdf" target="_blank">Audience Network</a> for Instant Articles.
-		<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty ( $fb_page_settings['page_id'] ) ) : ?>
+		<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty( $fb_page_settings['page_id'] ) ) : ?>
 			Sign up for Audience Network
 			<a
 				href="https://www.facebook.com/<?php echo esc_attr( $fb_page_settings['page_id'] ); ?>/settings/?tab=instant_articles#Audience-Network" target="_blank">here</a>.
 		<?php endif; ?>
 	<li>[Optional] Set up your ads and analytics, including Audience Network, in the Configuration area, below.
-	<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty ( $fb_page_settings['page_id'] ) ) : ?>
+	<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty( $fb_page_settings['page_id'] ) ) : ?>
 		<li>
 			<a
 			href="https://www.facebook.com/<?php echo esc_attr( $fb_page_settings['page_id'] ); ?>/settings/?tab=instant_articles#Setup-Step2" target="_blank">Submit your articles for review</a>.
@@ -42,7 +42,7 @@
 <ol>
 	<li>See the Instant Articles <a href="https://developers.facebook.com/docs/instant-articles" target="_blank">documentation</a> to answer any questions you might have about Instant Articles.
 	<li>Check out the Instant Articles <a href="https://developers.facebook.com/ia/blog/" target="_blank">blog</a> and sign up to receive notifications of important updates.
-	<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty ( $fb_page_settings['page_id'] ) ) : ?>
+	<?php if ( isset( $fb_page_settings['page_id'] ) && ! empty( $fb_page_settings['page_id'] ) ) : ?>
 		<li>
 			To give other members of your team access to your Instant Articles
 			<a

--- a/settings/template-settings-wizard.php
+++ b/settings/template-settings-wizard.php
@@ -7,7 +7,7 @@
  * @package default
  */
 
-  if ( Instant_Articles_Settings_Wizard::get_current_step_id() === 'done' ) : ?>
+if ( Instant_Articles_Settings_Wizard::get_current_step_id() === 'done' ) : ?>
 
 	<p><strong>Success! Your Instant Articles plugin has been activated.</strong></p>
 
@@ -20,8 +20,8 @@
 				echo esc_html( $fb_app_settings['app_id'] );
 			?></a>.
 
-				<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
-				<?php submit_button( __( 'Update' ), 'default', 'submit', false ); ?>
+			<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
+			<?php submit_button( __( 'Update' ), 'default', 'submit', false ); ?>
 		</p>
 	</form>
 
@@ -29,15 +29,15 @@
 		<p>
 			Your page is
 			<a
-				href="http://facebook.com/<?php echo esc_attr( $fb_page_settings['page_id'] ); ?>"
-				target="_blank"><?php
+		  href="http://facebook.com/<?php echo esc_attr( $fb_page_settings['page_id'] ); ?>"
+		  target="_blank"><?php
 				echo esc_html( $fb_page_settings['page_name'] );
 			?></a>.
-				<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
-				<?php submit_button( __( 'Update' ), 'default', 'submit', false ); ?>
-				<div style="display: none">
-					<?php do_settings_sections( Instant_Articles_Option_FB_App::OPTION_KEY ); ?>
-				</div>
+			<?php settings_fields( Instant_Articles_Option::PAGE_OPTION_GROUP_WIZARD ); ?>
+			<?php submit_button( __( 'Update' ), 'default', 'submit', false ); ?>
+		  <div style="display: none">
+				<?php do_settings_sections( Instant_Articles_Option_FB_App::OPTION_KEY ); ?>
+		  </div>
 		</p>
 	</form>
 
@@ -142,7 +142,7 @@
 					'page_id' => $page_node->getField( 'id' ),
 					'page_name' => $page_node->getField( 'name' ),
 					'page_access_token' => $page_node->getField( 'access_token' ),
-					'supports_instant_articles' => $page_node->getField( 'supports_instant_articles' )
+					'supports_instant_articles' => $page_node->getField( 'supports_instant_articles' ),
 				);
 			}, $helper->getPagesAndTokens( $access_token )->all() );
 
@@ -151,7 +151,7 @@
 			} );
 			?>
 
-			<?php if ( ! empty ( $pages_and_tokens ) ) : ?>
+			<?php if ( ! empty( $pages_and_tokens ) ) : ?>
 				<p>Select the Facebook Pages where you will publish Instant Articles:</p>
 
 				<select id="<?php echo esc_attr( 'instant-articles-fb-page-selector' ) ?>">

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -24,10 +24,10 @@ add_action( 'template_redirect', 'wpcom_fbia_stats_pixel' );
 function _wpcom_fbia_stats_pixel( $content ) {
 	global $post, $current_blog;
 
-	if( ! is_feed() )
-		return $content;
+	if ( ! is_feed() ) {
+		return $content; }
 
-	$url = 'https://pixel.wp.com/b.gif?host=' . $_SERVER[ 'HTTP_HOST' ] . '&blog=' . $current_blog->blog_id . '&post=' . $post->ID . '&subd=' . str_replace( '.wordpress.com', '', $current_blog->domain ) . '&ref=&feed=1';
+	$url = 'https://pixel.wp.com/b.gif?host=' . $_SERVER['HTTP_HOST'] . '&blog=' . $current_blog->blog_id . '&post=' . $post->ID . '&subd=' . str_replace( '.wordpress.com', '', $current_blog->domain ) . '&ref=&feed=1';
 
 	$fbia_pixel = '
 <figure class="op-tracker">


### PR DESCRIPTION
This fixes spaces around parentheses, braces and other characters to conform to WordPress coding standards.

Fixes made automatically with `phpcbf`.