### PR TITLE
always use HTTPS to load JavaScript SDK; update to 2.6

### DIFF
--- a/compat/class-instant-articles-jetpack.php
+++ b/compat/class-instant-articles-jetpack.php
@@ -78,7 +78,7 @@ class Instant_Articles_Jetpack {
 			$locale = 'en_US';
 		}
 
-		return '<figure class="op-social"><iframe><script src="//connect.facebook.net/' . $locale . '/sdk.js#xfbml=1&amp;version=v2.2" async></script><div class="fb-post" data-href="' . esc_url( $url ) . '"></div></iframe></figure>';
+		return '<figure class="op-social"><iframe><script src="https://connect.facebook.net/' . $locale . '/sdk.js#xfbml=1&amp;version=v2.6" async></script><div class="fb-post" data-href="' . esc_url( $url ) . '"></div></iframe></figure>';
 	}
 
 }


### PR DESCRIPTION
The Facebook SDK should always be loaded over HTTPS. We shouldn't use a protocol-relative URL.

Also bumped the SDK version to 2.6, which is current.