### PR TITLE
Update rules-configuration.json for FB SDK 1.2.0

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -80,6 +80,16 @@
             }
         }
     }, {
+        "class": "ImageInsideParagraphRule",
+        "selector": "//a[img]",
+        "properties": {
+            "image.url": {
+                "type": "string",
+                "selector": "img",
+                "attribute": "src"
+            }
+        }
+    }, {
         "class": "ListItemRule",
         "selector" : "li"
     }, {

--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -59,9 +59,9 @@
     }, {
         "class": "PassThroughRule",
         "selector": "blockquote p"
-    }, {
+    },{
         "class": "ImageRule",
-        "selector": "//p[img]",
+        "selector": "img",
         "properties": {
             "image.url": {
                 "type": "string",
@@ -69,8 +69,8 @@
                 "attribute": "src"
             }
         }
-    },{
-        "class": "ImageRule",
+    }, {
+        "class": "ImageInsideParagraphRule",
         "selector": "img",
         "properties": {
             "image.url": {
@@ -118,51 +118,6 @@
         "class": "H2Rule",
         "selector" : "h3,h4,h5,h6"
     }, {
-        "class": "SocialEmbedRule",
-        "selector" : "iframe",
-        "properties" : {
-            "socialembed.url" : {
-                "type" : "string",
-                "selector" : "iframe",
-                "attribute": "src"
-            },
-            "socialembed.iframe" : {
-                "type" : "children",
-                "selector" : "iframe"
-            },
-            "socialembed.caption" : {
-                "type" : "element",
-                "selector" : "figcaption"
-            }
-        }
-    }, {
-        "class": "SocialEmbedRule",
-        "selector" : "//p[iframe]",
-        "properties" : {
-            "socialembed.url" : {
-                "type" : "string",
-                "selector" : "iframe",
-                "attribute": "src"
-            },
-            "socialembed.iframe" : {
-                "type" : "children",
-                "selector" : "iframe"
-            },
-            "socialembed.caption" : {
-                "type" : "element",
-                "selector" : "figcaption"
-            }
-        }
-    }, {
-        "class": "SocialEmbedRule",
-        "selector" : "div.embed",
-        "properties" : {
-            "socialembed.iframe" : {
-                "type" : "children",
-                "selector" : "div.embed"
-            }
-        }
-    }, {
         "class": "InteractiveRule",
         "selector" : "div.interactive",
         "properties" : {
@@ -181,32 +136,12 @@
             }
         }
     }, {
-        "class": "SocialEmbedRule",
-        "selector" : "//div[@class='embed' and iframe]",
-        "properties" : {
-            "socialembed.url" : {
-                "type" : "string",
-                "selector" : "iframe",
-                "attribute": "src"
-            }
-        }
-    }, {
         "class": "InteractiveRule",
         "selector" : "//div[@class='interactive' and iframe]",
         "properties" : {
             "interactive.url" : {
                 "type" : "string",
                 "selector" : "iframe",
-                "attribute": "src"
-            }
-        }
-    }, {
-        "class": "ImageRule",
-        "selector": "//p[a[img]]|//a[img]",
-        "properties": {
-            "image.url": {
-                "type": "string",
-                "selector": "img",
                 "attribute": "src"
             }
         }
@@ -258,13 +193,13 @@
             }
         }
     }, {
-		"class": "InteractiveRule",
-		"selector" : "table",
-		"properties" : {
-			"interactive.iframe" : {
-				"type" : "element",
-				"selector" : "table"
-			}
-		}
-	}]
+        "class": "InteractiveRule",
+        "selector" : "table",
+        "properties" : {
+            "interactive.iframe" : {
+                "type" : "element",
+                "selector" : "table"
+            }
+        }
+    }]
 }


### PR DESCRIPTION
This PR:

* [x] updates transformer rules

Follows #

Relates to #
https://wordpress.org/support/topic/images-embedded-in-text

Fixes #

The Facebook Instant Articles SDK stable version is now 1.2.0 which updates the sample transformer for WP to accommodate images inside paragraphs
https://github.com/facebook/facebook-instant-articles-sdk-php/blob/master/tests/Facebook/InstantArticles/Transformer/CMS/wp-rules.json