### PR TITLE
Store and use submission ID when available to fetch the status

### DIFF
--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -18,6 +18,11 @@ use Facebook\Facebook;
 class Instant_Articles_Publisher {
 
 	/**
+	 * Key to store the submission status ID on meta data
+	 */
+	 const SUBMISSION_ID_KEY = 'instant_articles_submission_id';
+
+	/**
 	 * Inits publisher.
 	 */
 	public static function init() {
@@ -93,10 +98,12 @@ class Instant_Articles_Publisher {
 
 				try {
 					// Import the article.
-					$client->importArticle( $article, $take_live );
+					$submission_id = $client->importArticle( $article, $take_live );
+					update_post_meta( $post_id, self::SUBMISSION_ID_KEY, $submission_id );
 				} catch ( Exception $e ) {
 					// Try without taking live for pages not yet reviewed.
-					$client->importArticle( $article, false );
+					$submission_id = $client->importArticle( $article, false );
+					update_post_meta( $post_id, self::SUBMISSION_ID_KEY, $submission_id );
 				}
 			}
 		} catch ( Exception $e ) {

--- a/meta-box/class-instant-articles-meta-box.php
+++ b/meta-box/class-instant-articles-meta-box.php
@@ -57,7 +57,8 @@ class Instant_Articles_Meta_Box {
 	 * Renderer for the Metabox.
 	 */
 	public static function render_meta_box() {
-		$post = get_post( intval( filter_input( INPUT_POST, 'post_ID' ) ) );
+		$post_id = intval( filter_input( INPUT_POST, 'post_ID' ) );
+		$post = get_post( $post_id );
 		$adapter = new Instant_Articles_Post( $post );
 		$article = $adapter->to_instant_article();
 		$canonical_url = $adapter->get_canonical_url();
@@ -84,9 +85,14 @@ class Instant_Articles_Meta_Box {
 						$fb_page_settings['page_id']
 					);
 
-					// Grab the latest status of this article and display.
-					$article_id = $client->getArticleIDFromCanonicalURL( $canonical_url );
-					$submission_status = $client->getLastSubmissionStatus( $article_id );
+					$submission_status_id = get_post_meta( $post_id, Instant_Articles_Publisher::SUBMISSION_ID_KEY, true );
+					if ( ! empty( $submission_status_id ) ) {
+						$submission_status = $client->getSubmissionStatus( $submission_status_id );
+					} else {
+						// Grab the latest status of this article and display.
+						$article_id = $client->getArticleIDFromCanonicalURL( $canonical_url );
+						$submission_status = $client->getLastSubmissionStatus( $article_id );
+					}
 				}
 			} catch ( FacebookResponseException $e ) {
 				$submission_status = null;


### PR DESCRIPTION
This PR:

- Stores the submission ID of the posted article on post metadata.
- Uses the stored submission ID when available to fetch the article status instead of always getting it from the URL.

This fixes an issue where the meta-box does not show that the article was submitted unless you refresh the edit post screen, which feels broken.