### PR TITLE
Ensure that relative URL checking has a host and a path.

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -687,7 +687,7 @@ class Instant_Articles_Post {
 			foreach ( $scripts as $script ){
 				$src = $script->getAttribute( 'src' );
 				$explode_src = parse_url( $src );
-				if ( is_array( $explode_src ) && empty( $explode_src['scheme'] ) ) {
+				if ( is_array( $explode_src ) && empty( $explode_src['scheme'] ) && ! empty( $explode_src['host'] ) && ! empty( $explode_src['path'] ) ) {
 					$src = 'https://' . $explode_src['host'] . $explode_src['path'];
 				}
 				$script->setAttribute( 'src' , $src );


### PR DESCRIPTION
This PR solves an issue with PHP throwing an `Notice:  Undefined index: host in /var/www/lin/wp-content/themes/vip/plugins/facebook-instant-articles-3.0/class-instant-articles-post.php on line 691`.