### PR TITLE
Revert "escaping and sanitization fixes"

### DIFF
--- a/settings/class-instant-articles-option-ads.php
+++ b/settings/class-instant-articles-option-ads.php
@@ -134,7 +134,7 @@ class Instant_Articles_Option_Ads extends Instant_Articles_Option {
 
 		?>
 		</select>
-		<?php echo esc_html( $description ); ?>
+		<?php echo $description; ?>
 		<?php
 	}
 

--- a/settings/class-instant-articles-option-ads.php
+++ b/settings/class-instant-articles-option-ads.php
@@ -134,7 +134,7 @@ class Instant_Articles_Option_Ads extends Instant_Articles_Option {
 
 		?>
 		</select>
-		<?php echo $description; ?>
+		<?php echo wp_kses_post( $description ); ?>
 		<?php
 	}
 

--- a/settings/class-instant-articles-option.php
+++ b/settings/class-instant-articles-option.php
@@ -189,7 +189,7 @@ class Instant_Articles_Option {
 			$this->key,
 			esc_html( $title ),
 			function () use ( $description ) {
-				echo $description;
+				echo wp_kses_post( $description );
 			},
 			$this->key
 		);
@@ -314,7 +314,7 @@ class Instant_Articles_Option {
 				/>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo $field_description; ?>
+						<?php echo wp_kses_post( $field_description ); ?>
 					</p>
 				<?php endif; ?>
 				<?php
@@ -336,7 +336,7 @@ class Instant_Articles_Option {
 				</label>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo $field_description; ?>
+						<?php echo wp_kses_post( $field_description ); ?>
 					</p>
 				<?php endif; ?>
 				<?php
@@ -366,7 +366,7 @@ class Instant_Articles_Option {
 				</select>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo $field_description; ?>
+						<?php echo wp_kses_post( $field_description ); ?>
 					</p>
 				<?php endif; ?>
 				<?php
@@ -386,7 +386,7 @@ class Instant_Articles_Option {
 				><?php echo $args[ 'double_encode' ] ? htmlspecialchars( $option_value ) : esc_html( $option_value ); ?></textarea>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo $field_description; ?>
+						<?php echo wp_kses_post( $field_description); ?>
 					</p>
 				<?php endif; ?>
 				<?php
@@ -409,7 +409,7 @@ class Instant_Articles_Option {
 				/>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo $field_description; ?>
+						<?php echo wp_kses_post( $field_description ); ?>
 					</p>
 				<?php endif; ?>
 				<?php

--- a/settings/class-instant-articles-option.php
+++ b/settings/class-instant-articles-option.php
@@ -189,7 +189,7 @@ class Instant_Articles_Option {
 			$this->key,
 			esc_html( $title ),
 			function () use ( $description ) {
-				echo esc_html( $description );
+				echo $description;
 			},
 			$this->key
 		);
@@ -314,7 +314,7 @@ class Instant_Articles_Option {
 				/>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo esc_html( $field_description ); ?>
+						<?php echo $field_description; ?>
 					</p>
 				<?php endif; ?>
 				<?php
@@ -336,7 +336,7 @@ class Instant_Articles_Option {
 				</label>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo esc_html( $field_description ); ?>
+						<?php echo $field_description; ?>
 					</p>
 				<?php endif; ?>
 				<?php
@@ -366,7 +366,7 @@ class Instant_Articles_Option {
 				</select>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo esc_html( $field_description ); ?>
+						<?php echo $field_description; ?>
 					</p>
 				<?php endif; ?>
 				<?php
@@ -386,7 +386,7 @@ class Instant_Articles_Option {
 				><?php echo $args[ 'double_encode' ] ? htmlspecialchars( $option_value ) : esc_html( $option_value ); ?></textarea>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo esc_html( $field_description ); ?>
+						<?php echo $field_description; ?>
 					</p>
 				<?php endif; ?>
 				<?php
@@ -409,7 +409,7 @@ class Instant_Articles_Option {
 				/>
 				<?php if ( $field_description ) : ?>
 					<p class="description">
-						<?php echo esc_html( $field_description ); ?>
+						<?php echo $field_description; ?>
 					</p>
 				<?php endif; ?>
 				<?php

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -25,9 +25,12 @@ function _wpcom_fbia_stats_pixel( $content ) {
 	global $post, $current_blog;
 
 	if ( ! is_feed() ) {
-		return $content; }
+		return $content;
+	}
 
-	$url = 'https://pixel.wp.com/b.gif?host=' . $_SERVER['HTTP_HOST'] . '&blog=' . $current_blog->blog_id . '&post=' . $post->ID . '&subd=' . str_replace( '.wordpress.com', '', $current_blog->domain ) . '&ref=&feed=1';
+	$hostname = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''; // input var okay
+
+	$url = 'https://pixel.wp.com/b.gif?host=' . $hostname . '&blog=' . $current_blog->blog_id . '&post=' . $post->ID . '&subd=' . str_replace( '.wordpress.com', '', $current_blog->domain ) . '&ref=&feed=1';
 
 	$fbia_pixel = '
 <figure class="op-tracker">

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -25,12 +25,9 @@ function _wpcom_fbia_stats_pixel( $content ) {
 	global $post, $current_blog;
 
 	if ( ! is_feed() ) {
-		return $content;
-	}
+		return $content; }
 
-	$hostname = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''; // input var okay
-
-	$url = 'https://pixel.wp.com/b.gif?host=' . $hostname . '&blog=' . $current_blog->blog_id . '&post=' . $post->ID . '&subd=' . str_replace( '.wordpress.com', '', $current_blog->domain ) . '&ref=&feed=1';
+	$url = 'https://pixel.wp.com/b.gif?host=' . $_SERVER['HTTP_HOST'] . '&blog=' . $current_blog->blog_id . '&post=' . $post->ID . '&subd=' . str_replace( '.wordpress.com', '', $current_blog->domain ) . '&ref=&feed=1';
 
 	$fbia_pixel = '
 <figure class="op-tracker">


### PR DESCRIPTION
This reverts commit 232b2c9c734856c4e590eb329fd139a2fd5e8b3f.

The escaping here is breaking the UI, as the variables being escaped here DO contain HTML, although it is not user-generated HTML, but hardcoded HTML configured on the descriptions provided for each field.

![instant_articles_settings_ _diego_quinteiro_ _wordpress](https://cloud.githubusercontent.com/assets/1878108/16794005/77bb38f4-48ab-11e6-8511-55b1398b49c6.png)
