### PR TITLE
Improve rules for Images inside Paragraphs and Interactive elements

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -63,8 +63,8 @@
         "class": "PassThroughRule",
         "selector": "blockquote p"
     }, {
-        "class": "ImageRule",
-        "selector": "//p[img]",
+        "class": "ImageInsideParagraphRule",
+        "selector": "img",
         "properties": {
             "image.url": {
                 "type": "string",
@@ -291,13 +291,13 @@
             }
         }
     }, {
-		"class": "InteractiveRule",
-		"selector" : "table",
-		"properties" : {
-			"interactive.iframe" : {
-				"type" : "element",
-				"selector" : "table"
-			}
-		}
-	}]
+        "class": "InteractiveRule",
+        "selector" : "table",
+        "properties" : {
+            "interactive.iframe" : {
+            "type" : "element",
+            "selector" : "table"
+            }
+        }
+    }]
 }

--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -183,6 +183,16 @@
             "interactive.iframe" : {
                 "type" : "children",
                 "selector" : "div.embed"
+            },
+            "interactive.height" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "height"
+            },
+            "interactive.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
             }
         }
     }, {
@@ -198,9 +208,10 @@
                 "selector" : "iframe",
                 "attribute": "height"
             },
-            "interactive.iframe" : {
-                "type" : "children",
-                "selector" : "iframe"
+            "interactive.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
             }
         }
     }, {
@@ -231,6 +242,16 @@
                 "type" : "string",
                 "selector" : "iframe",
                 "attribute": "src"
+            },
+            "interactive.height" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "height"
+            },
+            "interactive.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
             }
         }
     }, {
@@ -295,8 +316,18 @@
         "selector" : "table",
         "properties" : {
             "interactive.iframe" : {
-            "type" : "element",
-            "selector" : "table"
+                "type" : "element",
+                "selector" : "table"
+            },
+            "interactive.height" : {
+                "type" : "int",
+                "selector" : "table",
+                "attribute": "height"
+            },
+            "interactive.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
             }
         }
     }]


### PR DESCRIPTION
This PR:

* [x] Fixes issue where text inline with images are being dropped.
* [x] Properly fetches width and height for Interactive elements
