### PR TITLE
Removed interactive.caption property from rule InteractiveRule

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -142,10 +142,6 @@
             "interactive.iframe" : {
                 "type" : "children",
                 "selector" : "iframe"
-            },
-            "interactive.caption" : {
-                "type" : "element",
-                "selector" : "figcaption"
             }
         }
     }, {
@@ -170,10 +166,6 @@
             "interactive.iframe" : {
                 "type" : "children",
                 "selector" : "iframe"
-            },
-            "interactive.caption" : {
-                "type" : "element",
-                "selector" : "figcaption"
             }
         }
     }, {


### PR DESCRIPTION
This PR:

* [x]  Cleans up the configuration property interactive.caption from rules, since it is not being used anymore

Relates to #361 


