### PR TITLE
Add subtitle to $header when rendering post to IA

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -625,6 +625,10 @@ class Instant_Articles_Post {
 			$transformer->transform( $header, $document );
 		}
 
+		if ( $this->has_subtitle() ) {
+			$header->withSubTitle ( $this->get_the_subtitle() ) ;
+		}
+
 		$authors = $this->get_the_authors();
 		foreach ( $authors as $author ) {
 			$author_obj = Author::create();


### PR DESCRIPTION
The plugin has functions built-in for subtitles; however it does not include it when constructing the header. Including it here allows users to use the built-in `instant_articles_subtitle` filter that allows users to target their subtitles, should they be part of their theme.

We’ve run into an issue during the submission process where subtitles where missing and Facebook mandating that we include them.