### PR TITLE
Jetpack plugin compatibility - Transformation rules

### DIFF
--- a/compat/class-instant-articles-jetpack.php
+++ b/compat/class-instant-articles-jetpack.php
@@ -15,7 +15,7 @@ class Instant_Articles_Jetpack {
 	function init() {
 		$this->_fix_youtube_embed();
 		$this->_fix_facebook_embed();
-		add_filter( 'instant_articles_transformer_rules_loaded', 'Instant_Articles_Jetpack::transformer_loaded' );
+		add_filter( 'instant_articles_transformer_rules_loaded', array( 'Instant_Articles_Jetpack', 'transformer_loaded' ) );
 	}
 
 	/**

--- a/compat/class-instant-articles-jetpack.php
+++ b/compat/class-instant-articles-jetpack.php
@@ -15,6 +15,7 @@ class Instant_Articles_Jetpack {
 	function init() {
 		$this->_fix_youtube_embed();
 		$this->_fix_facebook_embed();
+		add_filter( 'instant_articles_transformer_rules_loaded', 'Instant_Articles_Jetpack::transformer_loaded' );
 	}
 
 	/**
@@ -79,5 +80,14 @@ class Instant_Articles_Jetpack {
 		}
 
 		return '<figure class="op-social"><iframe><script src="https://connect.facebook.net/' . $locale . '/sdk.js#xfbml=1&amp;version=v2.6" async></script><div class="fb-post" data-href="' . esc_url( $url ) . '"></div></iframe></figure>';
+	}
+
+	public static function transformer_loaded( $transformer ) {
+		// Appends more rules to transformer
+		$file_path = plugin_dir_path( __FILE__ ) . 'jetpack-rules-configuration.json';
+		$configuration = file_get_contents( $file_path );
+		$transformer->loadRules( $configuration );
+
+		return $transformer;
 	}
 }

--- a/compat/jetpack-rules-configuration.json
+++ b/compat/jetpack-rules-configuration.json
@@ -1,0 +1,62 @@
+{
+  "rules":[
+    {
+      "class": "CaptionRule",
+      "selector" : "div.wp-caption-text"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.gallery-row"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.tiled-gallery p"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.gallery-row p"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.gallery-group p"
+    },
+    {
+      "class" : "PassThroughRule",
+      "selector" : "div.gallery-group"
+    },
+    {
+      "class": "ImageRule",
+      "selector" : "div.wp-caption",
+      "properties" : {
+          "image.url" : {
+              "type" : "string",
+              "selector" : "img",
+              "attribute": "src"
+          }
+      }
+    },
+    {
+      "class": "SlideshowImageRule",
+      "selector" : "div.tiled-gallery-item",
+      "properties" : {
+        "image.url" : {
+          "type" : "string",
+          "selector" : "img",
+          "attribute": "data-orig-file"
+        },
+        "caption.title" : {
+          "type" : "string",
+          "selector" : "div.tiled-gallery-caption"
+        }
+      }
+    },
+    {
+      "class": "SlideshowRule",
+      "selector" : "div.tiled-gallery"
+    },
+    {
+      "class": "CaptionRule",
+      "selector" : "div.tiled-gallery-caption"
+    }
+  ]
+}

--- a/compat/jetpack-rules-configuration.json
+++ b/compat/jetpack-rules-configuration.json
@@ -1,5 +1,8 @@
 {
-  "rules":[
+  "rules": [{
+      "class" : "IgnoreRule",
+      "selector" : "p.jetpack-slideshow-noscript"
+    },
     {
       "class": "CaptionRule",
       "selector" : "div.wp-caption-text"
@@ -53,6 +56,17 @@
     {
       "class": "SlideshowRule",
       "selector" : "div.tiled-gallery"
+    },
+    {
+      "class": "Compat\\JetpackSlideshowRule",
+      "selector" : "div.jetpack-slideshow",
+      "properties": {
+        "jetpack.data-gallery": {
+          "type": "json",
+          "selector": "div.jetpack-slideshow",
+          "attribute": "data-gallery"
+        }
+      }
     },
     {
       "class": "CaptionRule",


### PR DESCRIPTION
This PR:

* [x] Uses the new version of SDK with compat rules for Jetpack
* [x] Configures and sets the hook to apply Jetpack only if installed/activated
* [x] Configures the rules for Jetpack components: Slideshow and Tiled gallery

Relates to https://github.com/facebook/facebook-instant-articles-sdk-php/pull/150

Fixes #333, #319, #289, #133
