### PR TITLE
Commit blocker option - No warnings in transformer to publish

### DIFF
--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -89,6 +89,17 @@ class Instant_Articles_Publisher {
 					$dev_mode
 				);
 
+				// Don't process if contains warnings and blocker flag for transformation warnings is turned on.
+				if ( count( $adapter->transformer->getWarnings() ) > 0
+				  && isset( $publishing_settings['block_publish_with_warnings'] )
+					&& $publishing_settings['block_publish_with_warnings'] ) {
+
+					// Unpublishes if already published
+					$client->removeArticle( $article->get_canonical_url() );
+					delete_post_meta( $post_id, self::SUBMISSION_ID_KEY );
+					return;
+				}
+
 				if ( $dev_mode ) {
 					$take_live = false;
 				} else {

--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -95,7 +95,7 @@ class Instant_Articles_Publisher {
 					&& $publishing_settings['block_publish_with_warnings'] ) {
 
 					// Unpublishes if already published
-					$client->removeArticle( $article->get_canonical_url() );
+					$client->removeArticle( $article->getCanonicalURL() );
 					delete_post_meta( $post_id, self::SUBMISSION_ID_KEY );
 					return;
 				}

--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -25,7 +25,7 @@
         "selector" : "span"
     }, {
         "class": "ParagraphRule",
-        "selector": "p"
+        "selector": "pad"
     }, {
         "class": "LineBreakRule",
         "selector": "br"

--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -25,7 +25,7 @@
         "selector" : "span"
     }, {
         "class": "ParagraphRule",
-        "selector": "pad"
+        "selector": "p"
     }, {
         "class": "LineBreakRule",
         "selector": "br"

--- a/settings/class-instant-articles-option-publishing.php
+++ b/settings/class-instant-articles-option-publishing.php
@@ -47,6 +47,13 @@ class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
 			'default' => '',
 		),
 
+		'block_publish_with_warnings' => array(
+			'label' => 'Transformation warnings',
+			'description' => 'Articles won\'t be available as Instant Articles if transformation process contains warnings. Note: All warnings should be fixed in order to have them available as Instant Articles.',
+			'render' => 'checkbox',
+			'default' => false,
+			'checkbox_label' => 'Don\'t publish with warnings',
+		),
 	);
 
 	/**


### PR DESCRIPTION
This PR:

* [x] Creates a flag in settings "block_publish_with_warnings"
* [x] Flag defaults to false (disabled)
* [x] If flag is true and transformer results in warnings, Instant Article is not registered 

Depends on SDK: https://github.com/facebook/facebook-instant-articles-sdk-php/pull/154
