### PR TITLE
Don't call wpautop directly when trying to prepare content for transformation.

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -311,6 +311,11 @@ class Instant_Articles_Post {
 		 * @since 0.1
 		 * @param string  $content  The current post content.
 		 */
+
+		// Some people choose to disable wpautop. Due to the Instant Articles spec, we really want it in!
+		if ( ! has_filter( 'the_content', 'wpautop' ) )
+			add_filter( 'the_content', 'wpautop' );
+
 		$content = apply_filters( 'the_content', $content );
 
 		// Maybe cleanup some globals after us?
@@ -319,15 +324,12 @@ class Instant_Articles_Post {
 			wp_reset_postdata();
 		}
 
-		// Some people choose to disable wpautop. Due to the Instant Articles spec, we really want it in!
-		$content = wpautop( $content );
-
 		// Remove hyperlinks beginning with a # as they cause errors on Facebook (from http://wordpress.stackexchange.com/a/227332/19528)
 	        preg_match_all( '!<a[^>]*? href=[\'"]#[^<]+</a>!i', $content, $matches );
 	        foreach ( $matches[0] as $link ) {
 	                $content = str_replace( $link, strip_tags($link), $content );
 	        }
-		
+
 		/**
 		 * Filter the post content for Instant Articles.
 		 *


### PR DESCRIPTION
Instead check whether wpautop is attached for 'the_content' and if it's not, add it. The reason for this is that we applied the_content filters already, and the shortcodes were rendered. Calling wpautop after shortcodes are rendered will mangle most of them, unless shortcode returns 1 line of code.