### PR TITLE
Fix updating published posts result in error

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -621,7 +621,9 @@ class Instant_Articles_Post {
 		$title = $this->get_the_title();
 		if ( $title ) {
 			$document = new DOMDocument();
+			libxml_use_internal_errors(true);
 			$document->loadHTML( '<?xml encoding="' . $blog_charset . '" ?><h1>' . $title . '</h1>' );
+			libxml_use_internal_errors(false);
 			$transformer->transform( $header, $document );
 		}
 


### PR DESCRIPTION
#This PR:

* [x] Fixed error that occurs when updating a post that is already published, which prevent the changes from being published (it still gets saved as revision)

Fixes this issue #382 

Issue was intermittent and could be related to whether Instant Articles are under review on Facebook side (and thus disabling ability to delete Instant Articles on Facebook)

Fix suggested by @everton-rosario and worked for me.