### PR TITLE
Implemented compat for the get-the-image plugin

### DIFF
--- a/compat.php
+++ b/compat.php
@@ -7,6 +7,11 @@
  * @package default
  */
 
+if ( !function_exists( 'is_plugin_active' ) ) {
+	require_once ( ABSPATH . '/wp-admin/includes/plugin.php' );
+}
+
+
 // Load compat layer for Co-Authors Plus.
 if ( function_exists( 'get_coauthors' ) && ! defined( 'CAP_IA_COMPAT' ) ) {
 	include( dirname( __FILE__ ) . '/compat/class-instant-articles-co-authors-plus.php' );
@@ -33,4 +38,11 @@ if ( defined( 'JETPACK__VERSION' ) ) {
 	include( dirname( __FILE__ ) . '/compat/class-instant-articles-jetpack.php' );
 	$jp = new Instant_Articles_Jetpack;
 	$jp->init();
+}
+
+// Load support for Get The Image plugin
+if ( is_plugin_active( 'get-the-image/get-the-image.php' ) ) {
+	include( dirname( __FILE__ ) . '/compat/class-instant-articles-get-the-image.php' );
+	$gti = new Instant_Articles_Get_The_Image;
+	$gti->init();
 }

--- a/compat/class-instant-articles-get-the-image.php
+++ b/compat/class-instant-articles-get-the-image.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Support class for Get The Image plugin
+ *
+ * @since 3.0.2+
+ *
+ */
+class Instant_Articles_Get_The_Image {
+
+	/**
+	 * Init the compat layer
+	 *
+	 */
+	function init() {
+		add_filter( 'instant_articles_transformer_rules_loaded', array( 'Instant_Articles_Get_The_Image', 'transformer_loaded' ) );
+	}
+
+	public static function transformer_loaded( $transformer ) {
+		// Appends more rules to transformer
+		$file_path = plugin_dir_path( __FILE__ ) . 'get-the-image-rules-configuration.json';
+		$configuration = file_get_contents( $file_path );
+		$transformer->loadRules( $configuration );
+
+		return $transformer;
+	}
+}

--- a/compat/get-the-image-rules-configuration.json
+++ b/compat/get-the-image-rules-configuration.json
@@ -1,0 +1,13 @@
+{
+  "rules": [{
+      "class": "ImageInsideParagraphRule",
+      "selector": "figure.wp-caption",
+      "properties": {
+        "image.url": {
+          "type": "string",
+          "selector": "img",
+          "attribute": "src"
+        }
+      }
+    }]
+}


### PR DESCRIPTION
This PR:

* [x] Adds configuration rules for the get-the-image plugin
* [x] Compat layer setup with the new plugin


Fixes #381

