### PR TITLE
introduce portable-utf8 lib

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -17,6 +17,8 @@ use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Footer;
 use Facebook\InstantArticles\Transformer\Transformer;
+use voku\helper\UTF8;
+
 /**
  * Class responsible for constructing our content and preparing it for rendering
  *
@@ -682,7 +684,7 @@ class Instant_Articles_Post {
 		if ( function_exists( 'mb_convert_encoding' ) ) {
 			$content = mb_convert_encoding( $content, 'HTML-ENTITIES', get_option( 'blog_charset' ) );
 		} else {
-			$content = htmlspecialchars_decode( utf8_decode( htmlentities( $content, ENT_COMPAT, 'utf-8', false ) ) );
+			$content = htmlspecialchars_decode( UTF8::htmlentities( $content ) );
 		}
 
 		$result = $document->loadHTML( '<!doctype html><html><body>' . $content . '</body></html>' );

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
         "php": ">=5.4",
         "facebook/php-sdk-v4": "~5.0",
         "apache/log4php": "2.3.0",
-        "facebook/facebook-instant-articles-sdk-php": "^1.1.0"
+        "facebook/facebook-instant-articles-sdk-php": "^1.1.0",
+        "voku/portable-utf8": "^2.1"
     }
 }


### PR DESCRIPTION
This PR:

- [x] adds [`portable-utf8 library`](https://github.com/voku/portable-utf8) so multi-byte chars get converted properly even when mbstring is not available.

Fixes #384 #344

