### PR TITLE
Revert "Redirect settings"

### DIFF
--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -86,20 +86,8 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	function instant_articles_activate() {
 		instant_articles_init();
 		flush_rewrite_rules();
-		add_option( 'instant_articles_redirect_settings_flag', true );
 	}
 	register_activation_hook( __FILE__, 'instant_articles_activate' );
-	add_action( 'admin_init', 'instant_articles_redirect_settings' );
-
-	/**
-	 * The redirect when plugin got active.
-	 */
-	function instant_articles_redirect_settings() {
-		if ( get_option( 'instant_articles_redirect_settings_flag', false ) ) {
-			delete_option( 'instant_articles_redirect_settings_flag' );
-			exit( wp_redirect( Instant_Articles_Settings::get_href_to_settings_page() ) );
-		}
-	}
 
 	/**
 	 * Plugin activation hook to remove our rewrite rules.


### PR DESCRIPTION
Reverts Automattic/facebook-instant-articles-wp#389

While it's likely that a user will want to configure the plugin after activation, we shouldn't assume, and certainly shouldn't interrupt WP's normal behaviour.

A better approach would be a one-time post-activation admin message to point people to the settings page.