### PR TITLE
Only load compat layers when we're rendering a feed

### DIFF
--- a/compat/class-instant-articles-co-authors-plus.php
+++ b/compat/class-instant-articles-co-authors-plus.php
@@ -18,7 +18,10 @@ class Instant_Articles_Co_Authors_Plus {
 	 * Init the compat layer.
 	 */
 	function init() {
-		add_filter( 'instant_articles_authors', array( $this, 'authors' ), 10, 2 );
+		// Only make changes when we're building an FBIA response
+		if ( instant_articles_is_fbia_response() ) {
+			add_filter( 'instant_articles_authors', array( $this, 'authors' ), 10, 2 );
+		}
 	}
 
 	/**

--- a/compat/class-instant-articles-jetpack.php
+++ b/compat/class-instant-articles-jetpack.php
@@ -13,9 +13,12 @@ class Instant_Articles_Jetpack {
 	 *
 	 */
 	function init() {
-		$this->_fix_youtube_embed();
-		$this->_fix_facebook_embed();
-		add_filter( 'instant_articles_transformer_rules_loaded', array( 'Instant_Articles_Jetpack', 'transformer_loaded' ) );
+		// Only make changes when we're building an FBIA response
+		if ( instant_articles_is_fbia_response() ) {
+			$this->_fix_youtube_embed();
+			$this->_fix_facebook_embed();
+			add_filter( 'instant_articles_transformer_rules_loaded', array( 'Instant_Articles_Jetpack', 'transformer_loaded' ) );
+		}
 	}
 
 	/**

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -110,6 +110,16 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	add_action( 'plugins_loaded', 'instant_articles_load_textdomain' );
 
 	/**
+	 * Plugin hook to load compat layers.
+	 *
+	 * @since 2.0
+	 */
+	function instant_articles_load_compat() {
+		require_once( dirname( __FILE__ ) . '/compat.php' );
+	}
+	add_action( 'plugins_loaded', 'instant_articles_load_compat' );
+
+	/**
 	 * Register our special feed.
 	 *
 	 * @since 0.1
@@ -126,9 +136,6 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	 * @since 0.1
 	 */
 	function instant_articles_feed() {
-
-		// Load compat layers
-		require_once( dirname( __FILE__ ) . '/compat.php' );
 
 		// Load the feed template.
 		include( dirname( __FILE__ ) . '/feed-template.php' );

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -110,16 +110,6 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	add_action( 'plugins_loaded', 'instant_articles_load_textdomain' );
 
 	/**
-	 * Plugin hook to load compat layers.
-	 *
-	 * @since 2.0
-	 */
-	function instant_articles_load_compat() {
-		require_once( dirname( __FILE__ ) . '/compat.php' );
-	}
-	add_action( 'plugins_loaded', 'instant_articles_load_compat' );
-
-	/**
 	 * Register our special feed.
 	 *
 	 * @since 0.1
@@ -136,6 +126,9 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	 * @since 0.1
 	 */
 	function instant_articles_feed() {
+
+		// Load compat layers
+		require_once( dirname( __FILE__ ) . '/compat.php' );
 
 		// Load the feed template.
 		include( dirname( __FILE__ ) . '/feed-template.php' );

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -306,6 +306,29 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	}
 	add_action( 'wp_head', 'inject_url_claiming_meta_tag' );
 
+	/**
+	 * Helper which tells us if we're engaged in an FBIA response.
+	 *
+	 * During requests, we need to know if we need to generate and return FBIA-compatible
+	 * markup. If not, we shouldn't do anything to alter markup.
+	 *
+	 * @since 3.1
+	 *
+	 * @return bool True when we're returning FBIA markup
+	 */
+	function instant_articles_is_fbia_response() {
+		/**
+		 * Whether or not we're engaged in an FBIA response.
+		 *
+		 * Allows other parts of the plugin to define when we're responding with FBIA-compatible
+		 * markup, so that we can limit when we filter the content amongst other things.
+		 *
+		 * @since 3.1
+		 * @param bool Defaults to false. True when we are generating FBIA responses.
+		 */
+		return apply_filters( 'is_fbia_response', false );
+	}
+
 	// Initialize the Instant Articles settings page.
 	Instant_Articles_Settings::init();
 

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -137,6 +137,9 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	 */
 	function instant_articles_feed() {
 
+		// This is an FBIA response, so make sure we flag it as such
+		add_filter( 'is_fbia_response', true );
+
 		// Load the feed template.
 		include( dirname( __FILE__ ) . '/feed-template.php' );
 


### PR DESCRIPTION
The plugin currently does not load compat layers conditionally.

One result is that embeds (e.g. for Facebook) are transformed into FBIA markup for normal front-end posts. This means embeds don't render because they are not recognisable HTML.

This PR moves the loading of compat layers to the feed initiation so that we only load the compatibility code when we are definitely rendering the feed.
