### PR TITLE
Fix lingering reference to the old settings page on meta-box

### DIFF
--- a/meta-box/class-instant-articles-meta-box.php
+++ b/meta-box/class-instant-articles-meta-box.php
@@ -65,8 +65,8 @@ class Instant_Articles_Meta_Box {
 		$submission_status = null;
 		$published = 'publish' === $post->post_status;
 
-		Instant_Articles_Settings::menu_items();
-		$settings_page_href = Instant_Articles_Settings::get_href_to_settings_page();
+		Instant_Articles_Wizard::menu_items();
+		$settings_page_href = Instant_Articles_Wizard::get_url();
 
 		if ( $published ) {
 			try {


### PR DESCRIPTION
This PR removes a lingering reference to the old settings page removed on 3.1. This was breaking the meta-box.