### PR TITLE
Use the instant_articles_post_types filter when registering metaboxes

### DIFF
--- a/meta-box/class-instant-articles-meta-box.php
+++ b/meta-box/class-instant-articles-meta-box.php
@@ -38,7 +38,7 @@ class Instant_Articles_Meta_Box {
 			'instant_article_meta_box',
 			'Facebook Instant Articles',
 			array( 'Instant_Articles_Meta_Box', 'render_meta_box_loader' ),
-			'post',
+			apply_filters( 'instant_articles_post_types', array( 'post' ) ),
 			'normal',
 			'default'
 		);

--- a/meta-box/class-instant-articles-meta-box.php
+++ b/meta-box/class-instant-articles-meta-box.php
@@ -38,6 +38,8 @@ class Instant_Articles_Meta_Box {
 			'instant_article_meta_box',
 			'Facebook Instant Articles',
 			array( 'Instant_Articles_Meta_Box', 'render_meta_box_loader' ),
+
+			/** This filter is defined in facebook-instant-articles.php. */
 			apply_filters( 'instant_articles_post_types', array( 'post' ) ),
 			'normal',
 			'default'


### PR DESCRIPTION
This PR:

* [ ] Uses the already exiting `instant_articles_post_types` filter and applies to post type support in the `register_meta_box()` call.

Fixes #415 

