### PR TITLE
Call instant_articles_post_published hook to determine published status

### DIFF
--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -122,7 +122,7 @@ class Instant_Articles_Publisher {
 					$published = false;
 				} else {
 					// Any publish status other than 'publish' means draft for the Instant Article.
-					$published = apply_filters( 'instant_articles_post_published', true, $post->ID );
+					$published = apply_filters( 'instant_articles_post_published', true, $post_id );
 				}
 
 				try {

--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -122,7 +122,7 @@ class Instant_Articles_Publisher {
 					$published = false;
 				} else {
 					// Any publish status other than 'publish' means draft for the Instant Article.
-					$published = true;
+					$published = apply_filters( 'instant_articles_post_published', true, $post->ID );
 				}
 
 				try {


### PR DESCRIPTION
This adds a `instant_articles_post_published` hook to allow a plugin to change the `published` field on newly saved posts.
