### PR TITLE
Refactor to use transform string

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -633,11 +633,7 @@ class Instant_Articles_Post {
 
 		$title = $this->get_the_title();
 		if ( $title ) {
-			$document = new DOMDocument();
-			libxml_use_internal_errors(true);
-			$document->loadHTML( '<?xml encoding="' . $blog_charset . '" ?><h1>' . $title . '</h1>' );
-			libxml_use_internal_errors(false);
-			$transformer->transform( $header, $document );
+			$transformer->transformString( $header, '<h1>' . $title . '</h1>', $blog_charset );
 		}
 
 		if ( $this->has_subtitle() ) {
@@ -682,40 +678,7 @@ class Instant_Articles_Post {
 			$this->instant_article->withStyle( 'default' );
 		}
 
-		$libxml_previous_state = libxml_use_internal_errors( true );
-		$document = new DOMDocument( '1.0', get_option( 'blog_charset' ) );
-		$content = $this->get_the_content();
-
-		// DOMDocument isn’t handling encodings too well, so let’s help it a little.
-		if ( function_exists( 'mb_convert_encoding' ) ) {
-			$content = mb_convert_encoding( $content, 'HTML-ENTITIES', get_option( 'blog_charset' ) );
-		} else {
-			$content = htmlspecialchars_decode( utf8_decode( htmlentities( $content, ENT_COMPAT, 'utf-8', false ) ) );
-		}
-
-		$result = $document->loadHTML( '<!doctype html><html><body>' . $content . '</body></html>' );
-
-		// We need to make sure that scripts use absolute URLs and not relative URLs.
-		$scripts = $document->getElementsByTagName('script');
-		if ( ! empty( $scripts ) ) {
-			foreach ( $scripts as $script ){
-				$src = $script->getAttribute( 'src' );
-				$explode_src = parse_url( $src );
-				if ( is_array( $explode_src ) && empty( $explode_src['scheme'] ) && ! empty( $explode_src['host'] ) && ! empty( $explode_src['path'] ) ) {
-					$src = 'https://' . $explode_src['host'] . $explode_src['path'];
-				}
-				$script->setAttribute( 'src' , $src );
-			}
-		}
-
-		libxml_clear_errors();
-		libxml_use_internal_errors( $libxml_previous_state );
-
-		$document = apply_filters( 'instant_articles_parsed_document', $document );
-
-		if ( $result ) {
-			$transformer->transform( $this->instant_article, $document );
-		}
+		$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );
 
 		$this->add_ads_from_settings();
 		$this->add_analytics_from_settings();

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
         "php": ">=5.4",
         "facebook/php-sdk-v4": "~5.0",
         "apache/log4php": "2.3.0",
-        "facebook/facebook-instant-articles-sdk-php": "^1.1.0"
+        "facebook/facebook-instant-articles-sdk-php": "^1.5.0"
     }
 }


### PR DESCRIPTION
This PR:

* [x] improve encoding handling by IA the SDK function `transformString` and remove the complexities of `loadHTML` things.

Follows #395

Relates to #369, #344

Fixes #339