### PR TITLE
Only set https src on scripts that have a src attribute

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -704,6 +704,7 @@ class Instant_Articles_Post {
 					$explode_src = parse_url( $src );
 					if ( is_array( $explode_src ) && empty( $explode_src['scheme'] ) && ! empty( $explode_src['host'] ) && ! empty( $explode_src['path'] ) ) {
 						$src = 'https://' . $explode_src['host'] . $explode_src['path'];
+						$src = esc_url( $src );
 					}
 					$script->setAttribute( 'src' , $src );
 				}

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -700,11 +700,13 @@ class Instant_Articles_Post {
 		if ( ! empty( $scripts ) ) {
 			foreach ( $scripts as $script ){
 				$src = $script->getAttribute( 'src' );
-				$explode_src = parse_url( $src );
-				if ( is_array( $explode_src ) && empty( $explode_src['scheme'] ) && ! empty( $explode_src['host'] ) && ! empty( $explode_src['path'] ) ) {
-					$src = 'https://' . $explode_src['host'] . $explode_src['path'];
+				if ( ! empty( $src ) ) {
+					$explode_src = parse_url( $src );
+					if ( is_array( $explode_src ) && empty( $explode_src['scheme'] ) && ! empty( $explode_src['host'] ) && ! empty( $explode_src['path'] ) ) {
+						$src = 'https://' . $explode_src['host'] . $explode_src['path'];
+					}
+					$script->setAttribute( 'src' , $src );
 				}
-				$script->setAttribute( 'src' , $src );
 			}
 		}
 

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -703,8 +703,7 @@ class Instant_Articles_Post {
 				if ( ! empty( $src ) ) {
 					$explode_src = parse_url( $src );
 					if ( is_array( $explode_src ) && empty( $explode_src['scheme'] ) && ! empty( $explode_src['host'] ) && ! empty( $explode_src['path'] ) ) {
-						$src = 'https://' . $explode_src['host'] . $explode_src['path'];
-						$src = esc_url( $src );
+						$src = esc_url( 'https://' . $explode_src['host'] . $explode_src['path'] );
 					}
 					$script->setAttribute( 'src' , $src );
 				}


### PR DESCRIPTION
Fixes #447

Per the HTML5 spec, [if the src attribute is present on a script tag, the inner content must be empty](https://www.w3.org/TR/html5/scripting-1.html#the-script-element).

Setting all scripts to an absolute url using https protocol breaks script tags where the script is inline. (when a script tag This change checks to makes sure that the src attribute is not empty before updating it to an absolute url.



