### PR TITLE
Don't try to load FB embeds compat unless we're in Instant Articles context

### DIFF
--- a/compat/class-instant-articles-jetpack.php
+++ b/compat/class-instant-articles-jetpack.php
@@ -39,6 +39,11 @@ class Instant_Articles_Jetpack {
 	 */
 	private function _fix_facebook_embed() {
 
+		// Don't try to fix facebook embeds unless we're in Instant Articles context
+		// to prevent mangled output on frontend
+		if ( !doing_action( 'instant_articles_before_transform_post' ) )
+			return;
+
 		// All of these are registered in jetpack/modules/shortcodes/facebook.php
 
 		if ( defined( 'JETPACK_FACEBOOK_EMBED_REGEX' ) ) {
@@ -79,7 +84,7 @@ class Instant_Articles_Jetpack {
 			$locale = 'en_US';
 		}
 
-		return '<figure class="op-social"><iframe><script src="https://connect.facebook.net/' . $locale . '/sdk.js#xfbml=1&amp;version=v2.6" async></script><div class="fb-post" data-href="' . esc_url( $url ) . '"></div></iframe></figure>';
+		return '<figure class="op-interactive"><iframe><script src="https://connect.facebook.net/' . $locale . '/sdk.js#xfbml=1&amp;version=v2.6" async></script><div class="fb-post" data-href="' . esc_url( $url ) . '"></div></iframe></figure>';
 	}
 
 	public static function transformer_loaded( $transformer ) {


### PR DESCRIPTION
See #337 

Here's a different approach to #401 PR for that ticket,  this is just for fb embeds, I haven't tested it for the rest of the layers. 

The idea here is that 'instant_articles_before_transform' post runs only for IA context, so we can relatively safely attach our stuff here and it won't affect the rest of contexts.

Small extra - `op-social` was deprecated awhile back, so I replaced that with `op-interactive` 
