### PR TITLE
Issue 452 - Use of empty() on PHP prior to v5.5

### DIFF
--- a/wizard/class-instant-articles-option-publishing.php
+++ b/wizard/class-instant-articles-option-publishing.php
@@ -43,7 +43,7 @@ class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
 			'label' => '',
 			'render' => 'textarea',
 			'placeholder' => '{ "rules": [{ "class": "BoldRule", "selector": "span.bold" }, ... ] }',
-			'description' => 'Read more about <a href="https://github.com/facebook/facebook-instant-articles-sdk-php/blob/master/docs/QuickStart.md#custom-transformer-rules" target="_blank">defining your own custom rules</a> to extend/override the <a href="https://github.com/Automattic/facebook-instant-articles-wp/blob/master/rules-configuration.json" target="_blank">built-in ruleset</a>. If you\'ve defined a common rule which you think this plugin should include by default, <a href="https://github.com/Automattic/facebook-instant-articles-wp/issues/new" target="_blank">tell us about it</a>!',
+			'description' => 'Read more about <a href="https://developers.facebook.com/docs/instant-articles/sdk/transformer-rules" target="_blank">defining your own custom rules</a> to extend/override the <a href="https://github.com/Automattic/facebook-instant-articles-wp/blob/master/rules-configuration.json" target="_blank">built-in ruleset</a>. If you\'ve defined a common rule which you think this plugin should include by default, <a href="https://github.com/Automattic/facebook-instant-articles-wp/issues/new" target="_blank">tell us about it</a>!',
 			'default' => '',
 		),
 

--- a/wizard/templates/app-setup-template.php
+++ b/wizard/templates/app-setup-template.php
@@ -12,7 +12,7 @@
 	<!-- Step 1: grab your App ID and App Secret -->
 	<div class="instant-articles-card">
 		<div class="instant-articles-card-title">
-			<h3>Log In with Your Developers App and Facebook Account</h3>
+			<h3>Log In With Your Developers App and Facebook Account</h3>
 			<div class="instant-articles-card-title-right">
 				<span class="instant-articles-card-title-step">Step 1 of 2</span>
 			</div>

--- a/wizard/templates/app-setup-template.php
+++ b/wizard/templates/app-setup-template.php
@@ -27,7 +27,7 @@
 
 				<p><strong>Need to create one?</strong></p>
 
-				<p>Click on the 'Get App ID' button below to begin the process of getting your App ID and Secret.  This will open the App set up page in a new tab. Then, follow these steps:</p>
+				<p>Click on the 'Get App ID' button below to begin the process of getting your App ID and Secret. This will open the app set up page in a new tab. Then, follow these steps:</p>
 
 				<ol>
 					<li>Click on the green '+ Add a New App' button in the upper right corner of the page.</li>
@@ -40,7 +40,7 @@
 					<li>Select 'Show' to see your App Secret. Copy your App ID and Secret and enter them to the right.</li>
 				</ol>
 
-				<p><strong>Need more help?</strong> <a href="https://developers.facebook.com/docs/instant-articles/wordpress-quickstart#appid" target="_blank">See detailed instructions on setting up your App ID in our documentation</a>.</p>
+				<p>For more detailed instructions on setting up your App ID, <a href="https://developers.facebook.com/docs/instant-articles/wordpress-quickstart#appid" target="_blank">check out the docs</a>.</p>
 
 				<a class="instant-articles-button" href="https://developers.facebook.com/apps" target="_blank">
 					Get App ID

--- a/wizard/templates/app-setup-template.php
+++ b/wizard/templates/app-setup-template.php
@@ -23,11 +23,11 @@
 
 				<p>You'll need to log in with your Facebook Developers App ID to connect your plugin to the Facebook Page you'll use to publish your Instant Articles.</p>
 
-				<p><strong>Already have an App ID and Secret?</strong> Just enter them to the right.</p>
+				<p><strong>Already have an App ID and App Secret?</strong> Just enter them to the right.</p>
 
 				<p><strong>Need to create one?</strong></p>
 
-				<p>Click on the 'Get App ID' button below to begin the process of getting your App ID and Secret. This will open the app set up page in a new tab. Then, follow these steps:</p>
+				<p>Click on the 'Get App ID' button below to begin the process of getting your App ID and App Secret. This will open the app set up page in a new tab. Then, follow these steps:</p>
 
 				<ol>
 					<li>Click on the green '+ Add a New App' button in the upper right corner of the page.</li>
@@ -37,7 +37,7 @@
 					<li>Click '+Add Platform' at the bottom of the page and select 'Website.'</li>
 					<li>Under both the 'App Domains' in the main section and 'Site URL' in the 'Website' section, enter this domain: <b><?php echo esc_url( self::get_admin_url() ); ?></b></li>
 					<li>Click 'Save Changes' in the lower right corner.</li>
-					<li>Select 'Show' to see your App Secret. Copy your App ID and Secret and enter them to the right.</li>
+					<li>Select 'Show' to see your App Secret. Copy your App ID and App Secret and enter them to the right.</li>
 				</ol>
 
 				<p>For more detailed instructions on setting up your App ID, <a href="https://developers.facebook.com/docs/instant-articles/wordpress-quickstart#appid" target="_blank">check out the docs</a>.</p>

--- a/wizard/templates/overview-template.php
+++ b/wizard/templates/overview-template.php
@@ -15,7 +15,7 @@
 				<div class="instant-articles-card-step">
 					<img src="<?php echo esc_url( plugin_dir_url( __FILE__ ) ); ?>../../assets/key@2x.png">
 					<h4>Set Up and Log In</h4>
-					<p>If you don't have one already, set up your Facebook Developers App. Then log in to connect your plugin.</p>
+					<p>If you don't have one already, set up your Facebook Developers App. This will allow you to log in and connect your plugin.</p>
 				</div>
 				<div class="instant-articles-card-step">
 					<img src="<?php echo esc_url( plugin_dir_url( __FILE__ ) ); ?>../../assets/connect@2x.png">

--- a/wizard/templates/page-selection-template.php
+++ b/wizard/templates/page-selection-template.php
@@ -43,12 +43,10 @@
 						<img class="instant-articles-page-img" src="<?php echo esc_attr( $page[ 'page_picture' ] ) ?>"/>
 						<label>
 							<?php echo esc_html( $page[ 'page_name' ] ) ?>
-							<?php if ( $page[ 'supports_instant_articles' ] ) : ?>
-								<span class="page-enabled">✔ Enabled</span>
-							<?php else : ?>
+							<?php if ( ! $page[ 'supports_instant_articles' ] ) : ?>
 								<span class="page-not-enabled">
-									This page has not been signed up yet.
-									<a href="https://www.facebook.com/instant_articles/signup?redirect_uri=<?php echo urlencode( $settings_url ) ?>&page_id=<?php echo urlencode( $page[ 'page_id' ] ) ?>">Sign Up</a>.
+									First, <a href="https://www.facebook.com/instant_articles/signup?redirect_uri=<?php echo urlencode( $settings_url ) ?>&page_id=<?php echo urlencode( $page[ 'page_id' ] ) ?>">sign up</a>
+									this Page to access the Instant Articles tools through Facebook. Then select it here.
 								</span>
 							<?php endif; ?>
 						</label>

--- a/wizard/templates/style-selection-template.php
+++ b/wizard/templates/style-selection-template.php
@@ -40,12 +40,12 @@
 		<div class="instant-articles-card-content-box instant-articles-card-content-full">
 			<p>
 				Customize the look and feel of your articles with one or more unique styles.
-				Try to make your Instant Articles look as much like your mobile web articles as possible
-				and be sure to upload your publication or blog's logo.
+				Try to have design consistency between your Instant Articles and mobile
+				web articles and also ensure you upload your publication or blog's logo.
 				<a href="https://developers.facebook.com/docs/instant-articles/guides/design" target="_blank">Learn more in our design guidelines</a>.
 			</p>
 			<p>
-				Want to preview your style? Download Facebook Pages Manager on your
+				Want to preview how your articles will look? Download Facebook Pages Manager on your
 				<a href="https://itunes.apple.com/us/app/facebook-pages-manager/id514643583?mt=8" target="_blank">iPhone</a>
 				or
 				<a href="https://play.google.com/store/apps/details?id=com.facebook.pages.app" target="_blank">Android</a>

--- a/wizard/templates/wizard-template.php
+++ b/wizard/templates/wizard-template.php
@@ -98,7 +98,7 @@
 
 <?php if ( ! $ajax ) : ?>
 	</div>
-	<?php if ( ! empty( get_settings_errors() ) ) : ?>
+	<?php if ( count( get_settings_errors() ) !== 0 ) : ?>
 		<a class="instant-articles-advanced-settings instant-articles-wizard-toggle" href="#">▼ Advanced Settings</a>
 		<div class="instant-articles-wizard-advanced-settings-box" style="display: block;">
 			<?php include( dirname( __FILE__ ) . '/advanced-template.php' ); ?>


### PR DESCRIPTION
This PR:

* [x] Makes use of `count()` instead of `empty()` when checking for [`get_settings_errors()`](https://codex.wordpress.org/Function_Reference/get_settings_errors) since it always returns an Array.

Fixes #452
