### PR TITLE
Migration from old facebook sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": ">=5.4",
-        "facebook/php-sdk-v4": "~5.0",
+        "facebook/graph-sdk": "~5.0",
         "apache/log4php": "2.3.0",
         "facebook/facebook-instant-articles-sdk-php": "^1.1.0"
     }


### PR DESCRIPTION
This PR:

* [x] Removes dependency facebook/php-sdk-v4
* [x]  Adds the new package facebook/graph-sdk

Relates to warning on build