### PR TITLE
Fixes #452 - Use of empty() on PHP prior to v5.5

### DIFF
--- a/wizard/templates/wizard-template.php
+++ b/wizard/templates/wizard-template.php
@@ -98,7 +98,7 @@
 
 <?php if ( ! $ajax ) : ?>
 	</div>
-	<?php if ( ! empty( get_settings_errors() ) ) : ?>
+	<?php if ( count( get_settings_errors() ) !== 0 ) : ?>
 		<a class="instant-articles-advanced-settings instant-articles-wizard-toggle" href="#">▼ Advanced Settings</a>
 		<div class="instant-articles-wizard-advanced-settings-box" style="display: block;">
 			<?php include( dirname( __FILE__ ) . '/advanced-template.php' ); ?>


### PR DESCRIPTION
This PR:

* [x] Makes use of `count()` instead of `empty()` when checking for [`get_settings_errors()`](https://codex.wordpress.org/Function_Reference/get_settings_errors) since it always returns an Array.

Fixes #452