### PR TITLE
Apply the second argument to `the_title`

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -90,8 +90,9 @@ class Instant_Articles_Post {
 		 *
 		 * @since 3.1
 		 * @param string  $title  The current post title.
+		 * @param int     $id     The current post ID.
 		 */
-		$title = apply_filters( 'the_title', $title);
+		$title = apply_filters( 'the_title', $title, $this->_post->ID );
 
 		/**
 		 * Filter the post title for use in instant articles.


### PR DESCRIPTION
As per [core documentation](https://codex.wordpress.org/Plugin_API/Filter_Reference/the_title), include the second argument to `the_title` as the current post ID.

Relates to #394