### PR TITLE
Getter was renamed on SDK, updating here too

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -131,7 +131,7 @@
                         "type": "element",
                         "selector": "blockquote"
                     }, {
-                        "type": "sibling-element",
+                        "type": "next-sibling-element-of",
                         "selector": "blockquote"
                     }
                 ]


### PR DESCRIPTION
This fixes the name of the getter to the correct one on the SDK.
