### PR TITLE
Add instant_articles_should_submit_post filter hook  to allow developers control of whether the post should be submitted to IA

### DIFF
--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -57,6 +57,11 @@ class Instant_Articles_Publisher {
 		// Transform the post to an Instant Article.
 		$adapter = new Instant_Articles_Post( $post );
 
+		// Allow to disable post submit via filter
+		if ( false === apply_filters( 'instant_articles_should_submit_post', true, $adapter ) ) {
+			return;
+		}
+
 		$article = $adapter->to_instant_article();
 
 		// Skip empty articles or articles missing title.

--- a/feed-template.php
+++ b/feed-template.php
@@ -21,6 +21,11 @@ $last_modified = null;
 			<?php
 			$instant_article_post = new Instant_Articles_Post( get_post( get_the_id() ) );
 
+			// Allow to disable post submit via filter
+			if ( false === apply_filters( 'instant_articles_should_submit_post', true, $instant_article_post ) ) {
+				continue;
+			}
+
 			// If we’re OK with a limited post set: Do not include posts with empty content -- FB will complain.
 			if ( defined( 'INSTANT_ARTICLES_LIMIT_POSTS' ) && INSTANT_ARTICLES_LIMIT_POSTS && ! strlen( trim( $instant_article_post->get_the_content() ) ) ) {
 				continue;


### PR DESCRIPTION
This PR:

adds `instant_articles_should_submit_post` filter hook to allow developers to control whether current post should be submitted to Instant Articles or not. 

The filter defaults to `TRUE` - the  post should be submitted to IA. We pass instance of Instant_Articles_Post to the filter.

Relates to #503 442 #275 #186

Fixes #503
