### PR TITLE
Update WordPress.com stats code to use FBIA SDK.

### DIFF
--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -1,8 +1,10 @@
 <?php
 
+use Facebook\InstantArticles\Elements\Analytics;
+
 // Wrap the wpcom tracking pixel to comply with the FBIA spec
 // https://developers.facebook.com/docs/instant-articles/reference/analytics
-function wpcom_fbia_stats_pixel() {
+function wpcom_fbia_remove_stats_pixel() {
 	global $post;
 
 	if ( ! defined( 'INSTANT_ARTICLES_SLUG' ) ) {
@@ -16,34 +18,32 @@ function wpcom_fbia_stats_pixel() {
 	// Stop wpcom adding the tracking pixel
 	remove_filter( 'the_content', 'add_bug_to_feed', 100 );
 
-	add_filter( 'the_content', '_wpcom_fbia_stats_pixel', 100 );
-
 }
-add_action( 'template_redirect', 'wpcom_fbia_stats_pixel' );
+add_action( 'template_redirect', 'wpcom_fbia_remove_stats_pixel' );
 
-function _wpcom_fbia_stats_pixel( $content ) {
-	global $post, $current_blog;
+function wpcom_fbia_add_stats_pixel( $ia_post ) {
 
-	if ( ! is_feed() ) {
-		return $content;
-	}
+	// Get the IA article.
+	$instant_article = $ia_post->instant_article;
 
+	// Create the wpcom stats code.
 	$hostname = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''; // input var okay
 
 	$url = 'https://pixel.wp.com/b.gif?host=' . $hostname . '&blog=' . $current_blog->blog_id . '&post=' . $post->ID . '&subd=' . str_replace( '.wordpress.com', '', $current_blog->domain ) . '&ref=&feed=1';
 
-	$fbia_pixel = '
-<figure class="op-tracker">
-	<iframe>
-		<script>
-			var x = new Image(); x.src = "' . esc_js( $url ) . '&rand=" +Math.random();
-		</script>
-	</iframe>
-</figure>';
+	$pixel_html = '<script>
+		var x = new Image(); x.src = "' . esc_js( $url ) . '&rand=" +Math.random();
+	</script>';
 
-	return $content . $fbia_pixel;
+	// Create our FBIA markup
+	$fbia_markup = Analytics::create();
+	$fbia_markup->withHTML( $pixel_html );
+
+	// Add the FBIA-compatible stats markup to the IA content
+	$instant_article->addChild( $fbia_markup );
 
 }
+add_action( 'instant_articles_after_transform_post', 'wpcom_fbia_add_stats_pixel' );
 
 // make sure these function run in wp.com environment where `plugins_loaded` is already fired when loading the plugin
 add_action( 'after_setup_theme', 'instant_articles_load_textdomain' );


### PR DESCRIPTION
The WordPress.com stats pixel was being stripped out by the transformer. This change does several things;

* Adds the pixel via `instant_articles_after_transform_post`
* Uses the FBIA SDK to create FBIA-compatible markup for the stats pixel
* Adds the FBIA-compatible markup to the article

Tested on WordPress.com, but would appreciate a peer review and sanity check.