### PR TITLE
Show message on meta-box when post is filtered out

### DIFF
--- a/meta-box/class-instant-articles-meta-box.php
+++ b/meta-box/class-instant-articles-meta-box.php
@@ -84,6 +84,7 @@ class Instant_Articles_Meta_Box {
 		$published = 'publish' === $post->post_status;
 		$dev_mode = false;
 		$force_submit = get_post_meta( $post_id, Instant_Articles_Publisher::FORCE_SUBMIT_KEY, true );
+		$should_submit_post = apply_filters( 'instant_articles_should_submit_post', true, $adapter );
 
 		Instant_Articles_Wizard::menu_items();
 		$settings_page_href = Instant_Articles_Wizard::get_url();

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -18,7 +18,14 @@ use Facebook\InstantArticles\Client\ServerMessage;
 </a>
 <?php endif; ?>
 
-<?php if ( ! $published ) : ?>
+<?php if ( ! $shoud_publish_post ) : ?>
+<p>
+	<b>
+		<span class="dashicons dashicons-no-alt"></span>
+		This post will not be submitted to Instant Articles due to a rule created in your site.
+	</b>
+</p>
+<?php elseif ( ! $published ) : ?>
 <p>
 	<b>
 		<span class="dashicons dashicons-media-document"></span>


### PR DESCRIPTION
This PR:

* [x] Adds a message on the meta-box for when the post was filtered out programatically.

Follows #504 

