### PR TITLE
Remove deprecated rules and add rules for imgs inside links

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -63,7 +63,7 @@
         "class": "PassThroughRule",
         "selector": "blockquote p"
     }, {
-        "class": "ImageInsideParagraphRule",
+        "class": "ImageRule",
         "selector": "img",
         "properties": {
             "image.url": {
@@ -72,9 +72,9 @@
                 "attribute": "src"
             }
         }
-    },{
+    }, {
         "class": "ImageRule",
-        "selector": "img",
+        "selector": "//a[img and not(*[not(self::img)])]",
         "properties": {
             "image.url": {
                 "type": "string",
@@ -267,133 +267,6 @@
             "interactive.width" : {
                 "type" : "int",
                 "selector" : "iframe",
-                "attribute": "width"
-            }
-        }
-    }, {
-        "class": "InteractiveInsideParagraphRule",
-        "selector" : "iframe",
-        "properties" : {
-            "interactive.url" : {
-                "type" : "string",
-                "selector" : "iframe",
-                "attribute": "src"
-            },
-            "interactive.height" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "height"
-            },
-            "interactive.width" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "width"
-            }
-        }
-    },{
-        "class": "InteractiveInsideParagraphRule",
-        "selector" : "div.embed",
-        "properties" : {
-            "interactive.iframe" : {
-                "type" : "children",
-                "selector" : "div.embed"
-            },
-            "interactive.height" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "height"
-            },
-            "interactive.width" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "width"
-            }
-        }
-    }, {
-        "class": "InteractiveInsideParagraphRule",
-        "selector" : "div.interactive",
-        "properties" : {
-            "interactive.iframe" : {
-                "type" : "children",
-                "selector" : "div.interactive"
-            },
-            "interactive.height" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "height"
-            },
-            "interactive.width" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "width"
-            }
-        }
-    }, {
-        "class": "InteractiveInsideParagraphRule",
-        "selector" : "//div[@class='embed' and iframe]",
-        "properties" : {
-            "interactive.url" : {
-                "type" : "string",
-                "selector" : "iframe",
-                "attribute": "src"
-            },
-            "interactive.iframe" : {
-                "type" : "children",
-                "selector" : "iframe",
-                "attribute": "src"
-            },
-            "interactive.width" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "width"
-            },
-            "interactive.height" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "height"
-            }
-        }
-    }, {
-        "class": "InteractiveInsideParagraphRule",
-        "selector" : "//div[@class='interactive' and iframe]",
-        "properties" : {
-            "interactive.url" : {
-                "type" : "string",
-                "selector" : "iframe",
-                "attribute": "src"
-            },
-            "interactive.iframe" : {
-                "type" : "children",
-                "selector" : "iframe",
-                "attribute": "src"
-            },
-            "interactive.height" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "height"
-            },
-            "interactive.width" : {
-                "type" : "int",
-                "selector" : "iframe",
-                "attribute": "width"
-            }
-        }
-    }, {
-        "class": "InteractiveInsideParagraphRule",
-        "selector" : "table",
-        "properties" : {
-            "interactive.iframe" : {
-                "type" : "element",
-                "selector" : "table"
-            },
-            "interactive.height" : {
-                "type" : "int",
-                "selector" : "table",
-                "attribute": "height"
-            },
-            "interactive.width" : {
-                "type" : "int",
-                "selector" : "table",
                 "attribute": "width"
             }
         }


### PR DESCRIPTION
This PR:

* [x] Removes deprecated *InsideParagraph rules. See https://github.com/facebook/facebook-instant-articles-sdk-php/pull/186 for more details.
* [x] Adds support for images inside links

Fixes #429 

