### PR TITLE
Add release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 vendor
 composer.lock
+resty
+jsawk
+facebook-instant-articles-wp.zip

--- a/release.sh
+++ b/release.sh
@@ -4,6 +4,7 @@ green=`tput setaf 2`
 yellow=`tput setaf 3`
 blue=`tput setaf 4`
 reset=`tput sgr0`
+me='./'`basename "$0"`
 
 #--------------------------------
 # Functions
@@ -11,21 +12,42 @@ reset=`tput sgr0`
 function show_help {
 cat <<EOF
 
-Usage:
-  release.sh [-hvs] [-c <command>] [version]
+${green}Usage:${reset}
+  ${blue}${me} [-hvs] [-c <command>] [version]${reset}
 
-Arguments:
+${green}Arguments:${reset}
   release      - Creates a GitHub released based on existing version tag
   bump_version - Creates a new version tag
   version      - The target version (ex: 3.2.1)
 
-Options:
+${green}Options:${reset}
   -h            Display this help message
   -v            Verbose mode
   -s            Simulate only (do not release)
   -c <command>  Runs only a single command. Possible commands are:
-                  - bump_version: generate a new version tag
-                  - release: release a new version
+                  - bump_version: generate a new version tag on the repository
+                  - release: release a new version on GitHub
+
+${green}Examples:${reset}
+
+  ${blue}${me} 3.3.0${reset}
+    Runs bump_version then release for 3.3.0. This is the default use case.
+
+  ${blue}${me} -c bump_version 3.3.0${reset}
+    Generates a new commit on master changing the version to 3.3.0 in
+    all relevant files, tags the commit and pushes to remote.
+
+  ${blue}${me} -c release 3.3.0${reset}
+    Creates a new Release on GitHub based on the tag 3.3.0 and uploads
+    the binary package based on master.
+    ${red}IMPORTANT: this will create a new tag if tag 3.3.0 doesn't exist,
+    so make sure to bump_version beforehand.${reset}
+
+  ${blue}${me} -v 3.3.0${reset}
+    Releases 3.3.0 in verbose mode.
+
+  ${blue}${me} -s 3.3.0${reset}
+    Simulates a 3.3.0 release: prints the commands instead of running them.
 
 EOF
 }
@@ -33,7 +55,7 @@ EOF
 function invalid_usage {
   printf $red
   echo $@
-  echo "Aborting..."
+  echo "Aborted"
   printf $reset
   show_help
   exit -1;
@@ -41,7 +63,7 @@ function invalid_usage {
 function error_message {
   printf $red
   echo $@
-  echo "Aborting..."
+  echo "Aborted"
   printf $reset
   exit -1
 }
@@ -250,7 +272,7 @@ function bump_version {
 
   revert_repo
 
-  message "🍺  Tag $version created!"
+  echo "🍺  Tag $version created!"
 }
 
 function release {
@@ -316,7 +338,7 @@ function release {
   fi
 
   if [[ $response ]]; then
-    message "🍺  Binary file upload complete"
+    echo "🍺  Release $version successfully created"
   else
     error_message "Couldn't upload file"
   fi

--- a/release.sh
+++ b/release.sh
@@ -173,6 +173,8 @@ function revert_repo {
   run cd $repo_dir
   if [[ $branch_name != 'master' ]]; then
     message "Going back to $branch_name"
+    # stashes anything possibly left from the script execution
+    run git stash
     run git checkout $branch_name
   fi
   if [[ $stash_ref ]]; then
@@ -321,11 +323,11 @@ function release {
 
   if [[ ! -e resty ]]; then
     message "Downloading resty to connect to GitHub API"
-    run curl -L http://github.com/micha/resty/raw/master/resty > resty
+    run curl -L http://github.com/micha/resty/raw/2.2/resty > resty
   fi
   if [[ ! -e jsawk ]]; then
     message "Downloading jsawk to parse info from GitHub API"
-    run curl -L http://github.com/micha/jsawk/raw/master/jsawk > jsawk
+    run curl -L http://github.com/micha/jsawk/raw/1.4/jsawk > jsawk
   fi
 
   prompt "GitHub access-token (required only for 2fac):"
@@ -428,7 +430,9 @@ function publish {
 
   confirm "Copy new version to trunk?"
   run cp -rf $repo_dir/* ./
-  run rm -rf .[!.]*
+
+  # Removes development files we know shouldn't make to the SVN repo
+  run rm -rf .[!.]* # this will remove all hidden files
   run rm -rf bin
   run rm -rf tests
   run rm -rf composer*
@@ -438,6 +442,7 @@ function publish {
   run rm -rf jsawk
   run rm -rf resty
   run rm -rf vendor/apache/log4php/.git
+
   run svn st | grep '^\?' | sed 's/^\? *//' | xargs -I% svn add %
   run svn status
   ask "Review changes?"

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+red=`tput setaf 1`
+green=`tput setaf 2`
+yellow=`tput setaf 3`
+blue=`tput setaf 4`
+reset=`tput sgr0`
+
+#--------------------------------
+# Functions
+#--------------------------------
+function show_help {
+cat <<EOF
+
+Usage:
+  release.sh [-hvs] [version]
+
+Arguments:
+  version - The target version (ex: 3.2.1)
+
+Options:
+  -h Display this help message
+  -v Verbose mode
+  -s Simulate only (do not release)
+
+EOF
+}
+
+function invalid_usage {
+  printf $red
+  echo $@
+  echo "Aborting..."
+  printf $reset
+  show_help
+  exit -1;
+}
+function error_message {
+  printf $red
+  echo $@
+  echo "Aborting..."
+  printf $reset
+  exit -1
+}
+function message {
+  if [[ $verbose == 1 ]]; then
+    printf $green
+    echo $@
+    printf $reset
+  fi
+}
+function run_message {
+  if [[ $simulate == 1 ]]; then
+    printf $yellow
+    echo $@
+    printf $reset
+  fi
+}
+
+#----------------
+# Read parameters
+#----------------
+
+# A POSIX variable
+# Reset in case getopts has been used previously in the shell.
+OPTIND=1
+
+# Read options:
+verbose=0
+simulate=0
+
+while getopts "hvs" opt; do
+    case "$opt" in
+    h|\?)
+        show_help
+        exit 0
+        ;;
+    v)  verbose=1
+        ;;
+    s)  simulate=1
+        ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+# Read argument
+version=$1
+
+# Validates arguments
+if [[ $2 ]]; then
+  invalid_usage "Invalid parameters"
+fi
+
+if [[ ! $( echo $version | grep -Ee '^[0-9]+\.[0-9]+(\.[0-9]+)?$' ) ]]; then
+  invalid_usage "Invalid version provided"
+fi
+
+message "Releasing version: $version"
+message "Running in verbose mode"
+if [[ $simulate == 1 ]]; then
+  message "Running in simulation mode"
+fi
+
+#---------------------------------
+# Check if we have the right tools
+#---------------------------------
+
+if ! type "git" > /dev/null; then
+  error_message "git not found, please install git before continuing: http://git.org"
+else
+  message "Found git: $(git --version)"
+fi
+
+#------------------------------------
+# Check if we are in the right folder
+#------------------------------------
+if [[ ! -e '.git/config' ]]; then
+  error_message "You should run this command from the root directory of your repository."
+fi
+if [[ ! $( cat .git/config | grep -i 'automattic/facebook-instant-articles-wp') ]]; then
+  error_message "You should run this command from the root directory of the facebook-instant-articles-wp repository."
+fi
+
+#-------------------
+# Manages simulation
+#-------------------
+function run {
+  if [[ $simulate == 1 ]]; then
+    run_message $@
+  else
+    "$@"
+  fi
+}
+
+function revert_repo {
+  if [[ $branch_name != 'master' ]]; then
+    message "Going back to $branch_name"
+    run git checkout $branch_name
+  fi
+  if [[ $stash_ref ]]; then
+    message "Applying stashed changes"
+    run git stash apply $stash_ref
+  fi
+}
+
+function confirm {
+  confirm=''
+  while [[ $confirm != 'a' && $confirm != 'y' ]]; do
+    printf $blue
+    printf "%b" "$*"
+    printf ' (y)es/(a)bort: '
+    printf $red
+    read -n 1 confirm
+    printf "\n"
+  done
+  if [[ $confirm != 'y' ]]; then
+    revert_repo
+    error_message 'Execution aborted by the user'
+    exit -1
+  fi
+  printf $reset
+}
+
+#----------------------
+# Ok, let's get started
+#----------------------
+message "Stashing current work..."
+
+stash_ref=$(git stash create)
+run_message git stash create
+
+if [[ $stash_ref ]]; then
+  run git reset --hard
+  message "Stashed current work to: $stash_ref"
+else
+  message "Nothing to stash"
+fi
+
+branch_name="$(git symbolic-ref HEAD 2>/dev/null)"
+branch_name=${branch_name##refs/heads/}
+message "Current branch: $branch_name"
+
+if [[ $branch_name != 'master' ]]; then
+  message "Switching to master..."
+  run git checkout master
+fi
+
+message "Pulling latest version from GitHub"
+run git pull --rebase
+
+confirm "Replace stable tag on readme.txt with $version?"
+message "Replacing stable tag on readme.txt"
+run sed -i -e "s/Stable tag: .*/Stable tag: $version/" ./readme.txt
+run git diff
+confirm "Add changes to commit?"
+run git add readme.txt
+run rm readme.txt-e
+
+confirm "Replace version on facebook-instant-articles-wp.php with $version?"
+message "Replacing version on facebook-instant-articles-wp.php"
+run sed -i -e "s/^ \* Version: .*/ * Version: $version/" facebook-instant-articles.php
+run sed -i -e "s/define( 'IA_PLUGIN_VERSION', '[0-9.]*' );/define( 'IA_PLUGIN_VERSION', '$version' );/" facebook-instant-articles.php
+run git diff
+confirm "Add changes to commit?"
+run git add facebook-instant-articles-wp.php
+rum rm facebook-instant-articles-wp.php-e
+
+confirm "Commit version bump on master with message 'Bump version to $version'?"
+run git commit -m "Bump version to $version"
+
+confirm "Create tag $version?"
+run git tag $version
+
+confirm "Push tag and commit to GitHub?"
+run git push && git push --tags
+
+revert_repo


### PR DESCRIPTION
Created a script to automatically:

- [x] Bump the version of the plugin in the right files
- [x] Create a tag for the version
- [x] Commit and tag the repository with the version
- [x] Create a new release for the version
- [x] Uploads the binary zip for the plugin
- [x] Release on WordPress.org

Basic usage: ./release.sh -v <VERSION>