### PR TITLE
Add `is_transforming_instant_article()` conditional

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -595,6 +595,8 @@ class Instant_Articles_Post {
 		 */
 		do_action( 'instant_articles_before_transform_post', $this );
 
+		is_transforming_instant_article( true );
+
 		// Get time zone configured in WordPress. Default to UTC if no time zone configured.
 		$date_time_zone = get_option( 'timezone_string' ) ? new DateTimeZone( get_option( 'timezone_string' ) ) : new DateTimeZone( 'UTC' );
 
@@ -689,6 +691,8 @@ class Instant_Articles_Post {
 		$this->add_analytics_from_settings();
 
 		$this->instant_article = apply_filters( 'instant_articles_transformed_element', $this->instant_article );
+
+		is_transforming_instant_article( false );
 
 		/**
 		 * Fires after the instant article is rendered.

--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -62,7 +62,11 @@ class Instant_Articles_Publisher {
 			return;
 		}
 
+		is_instant_article( true );
+
 		$article = $adapter->to_instant_article();
+
+		is_instant_article( false );
 
 		// Skip empty articles or articles missing title.
 		// This is important because the save_post action is also triggered by bulk updates, but in this case

--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -62,11 +62,7 @@ class Instant_Articles_Publisher {
 			return;
 		}
 
-		is_instant_article( true );
-
 		$article = $adapter->to_instant_article();
-
-		is_instant_article( false );
 
 		// Skip empty articles or articles missing title.
 		// This is important because the save_post action is also triggered by bulk updates, but in this case

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -151,12 +151,29 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	 * @since 0.1
 	 */
 	function instant_articles_feed() {
+		is_instant_article( true );
 
 		// Load the feed template.
 		include( dirname( __FILE__ ) . '/feed-template.php' );
 
+		is_instant_article( false );
 	}
 
+	/**
+	 * Whether currently processing an instant article.
+	 *
+	 * @param bool Set the status
+	 * @return bool
+	 */
+	function is_instant_article( $set_status = null ) {
+		static $is_instant_article = false;
+
+		if ( isset( $set_status ) ) {
+			$is_instant_article = (bool) $set_status;
+		}
+
+		return $is_instant_article;
+	}
 
 	/**
 	 * Modify the main query for our feed.

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -172,8 +172,6 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 
 		return $is_instant_article;
 	}
-	add_action( 'instant_articles_before_transform_post', function() { is_transforming_instant_article( true ); } );
-	add_action( 'instant_articles_after_transform_post', function() { is_transforming_instant_article( false ); } );
 
 	/**
 	 * Modify the main query for our feed.

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -163,7 +163,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	 * @param bool Set the status
 	 * @return bool
 	 */
-	function is_instant_article( $set_status = null ) {
+	function is_transforming_instant_article( $set_status = null ) {
 		static $is_instant_article = false;
 
 		if ( isset( $set_status ) ) {
@@ -172,8 +172,8 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 
 		return $is_instant_article;
 	}
-	add_action( 'instant_articles_before_transform_post', function() { is_instant_article( true ); } );
-	add_action( 'instant_articles_after_transform_post', function() { is_instant_article( false ); } );
+	add_action( 'instant_articles_before_transform_post', function() { is_transforming_instant_article( true ); } );
+	add_action( 'instant_articles_after_transform_post', function() { is_transforming_instant_article( false ); } );
 
 	/**
 	 * Modify the main query for our feed.

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -151,12 +151,10 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	 * @since 0.1
 	 */
 	function instant_articles_feed() {
-		is_instant_article( true );
 
 		// Load the feed template.
 		include( dirname( __FILE__ ) . '/feed-template.php' );
 
-		is_instant_article( false );
 	}
 
 	/**
@@ -174,6 +172,8 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 
 		return $is_instant_article;
 	}
+	add_action( 'instant_articles_before_transform_post', function() { is_instant_article( true ); } );
+	add_action( 'instant_articles_after_transform_post', function() { is_instant_article( false ); } );
 
 	/**
 	 * Modify the main query for our feed.


### PR DESCRIPTION
Adds a new function in the global namespace to check if the current view
being processed is for an instant article. Handles both the RSS feed and
content which is being processed for the Instant_Articles_Publisher
class. This conditional can be checked in any filters on 'the_content',
'the_title' or elsewhere that need to treat Instant Articles content
separately from web content.

See #426