### PR TITLE
Add transformer rule for cite element

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -63,6 +63,9 @@
         "class": "PassThroughRule",
         "selector": "blockquote p"
     }, {
+        "class": "ItalicRule",
+        "selector": "cite"
+    }, {
         "class": "ImageRule",
         "selector": "img",
         "properties": {


### PR DESCRIPTION
This PR:

Adds a transformer rule for the cite element adding the ItalicRule class.