### PR TITLE
Don't try to load embeds compat unless we're in Instant Articles context

### DIFF
--- a/compat/class-instant-articles-jetpack.php
+++ b/compat/class-instant-articles-jetpack.php
@@ -39,10 +39,11 @@ class Instant_Articles_Jetpack {
 	 */
 	private function _fix_facebook_embed() {
 
-		// Don't try to fix facebook embeds unless we're in Instant Articles context
-		// to prevent mangled output on frontend
-		if ( !doing_action( 'instant_articles_before_transform_post' ) )
-			return;
+		// Don't try to fix facebook embeds unless we're in Instant Articles context.
+		// This prevents mangled output on frontend.
+		if ( ! is_transforming_instant_article() ) {
+		    return;
+		}
 
 		// All of these are registered in jetpack/modules/shortcodes/facebook.php
 

--- a/embeds.php
+++ b/embeds.php
@@ -68,6 +68,12 @@ add_filter( 'embed_oembed_html', 'instant_articles_embed_oembed_html', 10, 4 );
  */
 function instant_articles_embed_get_html( $provider_name, $html, $url, $attr, $post_id ) {
 
+	// Don't try to fix embeds unless we're in Instant Articles context.
+	// This prevents mangled output on frontend.
+	if ( ! is_transforming_instant_article() ) {
+			return $html;
+	}
+
 	/**
 	 * Filter the HTML that will go into the Instant Article Social Embed markup.
 	 *


### PR DESCRIPTION
This PR is built on top of #457 and using the solution introduced by #568.

It prevents the compat layer from messing with the regular FE output, running only during the Instant Article transformation.