### PR TITLE
Fix typo for $provider_url at L42, L44 and L46

### DIFF
--- a/embeds.php
+++ b/embeds.php
@@ -39,11 +39,11 @@ function instant_articles_embed_oembed_html( $html, $url, $attr, $post_id ) {
 		$provider_name = 'twitter';
 	} elseif ( false !== strpos( $provider_url, 'youtube.com' ) ) {
 		$provider_name = 'youtube';
-	} elseif( false !== strpos( $providerURL, 'vimeo.com' ) ) {
+	} elseif( false !== strpos( $provider_url, 'vimeo.com' ) ) {
 		$provider_name = 'vimeo';
-	} elseif( false !== strpos( $providerURL, 'vine.co' ) ) {
+	} elseif( false !== strpos( $provider_url, 'vine.co' ) ) {
 		$provider_name = 'vine';
-	} elseif( false !== strpos( $providerURL, 'facebook.com' ) ) {
+	} elseif( false !== strpos( $provider_url, 'facebook.com' ) ) {
 		$provider_name = 'facebook';
 	}
 


### PR DESCRIPTION
This PR:

Fixes #
few typos with variable spelling causing the added fix for Vimeo, Facebook and Vine not working.

