### PR TITLE
Switch on/off configuration for enabling comments/likes by default

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -685,6 +685,10 @@ class Instant_Articles_Post {
 			$this->instant_article->withStyle( 'default' );
 		}
 
+		if ( isset( $settings_style['rtl_enabled'] ) ) {
+			$this->instant_article->enableRTL();
+		}
+
 		$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );
 
 		$this->add_ads_from_settings();

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -688,14 +688,17 @@ class Instant_Articles_Post {
 		if ( isset( $settings_style['rtl_enabled'] ) ) {
 			$this->instant_article->enableRTL();
 		}
-		// Added condition checker based on general config to enable/disable the likes and comments on video and image
+		// This block sets as default likes and/or comments based on the configuration setup,
+		// and call $transformer->transform will consider the defaults before building the Elements
+		//
+		// Warning: if you are using pthreads or any other multithreaded engine, consider replicating this to all processes.
 		if ( isset( $settings_publishing[ 'likes_on_media' ] ) ) {
-			Image::$DEFAULT_LIKE_ENABLED = $settings_publishing[ 'likes_on_media' ];
-			Video::$DEFAULT_LIKE_ENABLED = $settings_publishing[ 'likes_on_media' ];
+			Image::setDefaultLikeEnabled( $settings_publishing[ 'likes_on_media' ] );
+			Video::setDefaultLikeEnabled( $settings_publishing[ 'likes_on_media' ] );
 		}
 		if ( isset( $settings_publishing[ 'comments_on_media' ] ) ) {
-			Image::$DEFAULT_COMMENT_ENABLED = $settings_publishing[ 'comments_on_media' ];
-			Video::$DEFAULT_COMMENT_ENABLED = $settings_publishing[ 'comments_on_media' ];
+			Image::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
+			Video::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
 		}
 
 		$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -688,6 +688,7 @@ class Instant_Articles_Post {
 		if ( isset( $settings_style['rtl_enabled'] ) ) {
 			$this->instant_article->enableRTL();
 		}
+
 		// This block sets as default likes and/or comments based on the configuration setup,
 		// and call $transformer->transform will consider the defaults before building the Elements
 		//

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -688,6 +688,15 @@ class Instant_Articles_Post {
 		if ( isset( $settings_style['rtl_enabled'] ) ) {
 			$this->instant_article->enableRTL();
 		}
+		// Added condition checker based on general config to enable/disable the likes and comments on video and image
+		if ( isset( $settings_publishing[ 'likes_on_media' ] ) ) {
+			Image::$DEFAULT_LIKE_ENABLED = $settings_publishing[ 'likes_on_media' ];
+			Video::$DEFAULT_LIKE_ENABLED = $settings_publishing[ 'likes_on_media' ];
+		}
+		if ( isset( $settings_publishing[ 'comments_on_media' ] ) ) {
+			Image::$DEFAULT_COMMENT_ENABLED = $settings_publishing[ 'comments_on_media' ];
+			Video::$DEFAULT_COMMENT_ENABLED = $settings_publishing[ 'comments_on_media' ];
+		}
 
 		$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );
 

--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -122,7 +122,7 @@ class Instant_Articles_Publisher {
 					$published = false;
 				} else {
 					// Any publish status other than 'publish' means draft for the Instant Article.
-					$published = true;
+					$published = apply_filters( 'instant_articles_post_published', true, $post_id );
 				}
 
 				try {

--- a/embeds.php
+++ b/embeds.php
@@ -39,11 +39,11 @@ function instant_articles_embed_oembed_html( $html, $url, $attr, $post_id ) {
 		$provider_name = 'twitter';
 	} elseif ( false !== strpos( $provider_url, 'youtube.com' ) ) {
 		$provider_name = 'youtube';
-	} elseif( false !== strpos( $providerURL, 'vimeo.com' ) ) {
+	} elseif( false !== strpos( $provider_url, 'vimeo.com' ) ) {
 		$provider_name = 'vimeo';
-	} elseif( false !== strpos( $providerURL, 'vine.co' ) ) {
+	} elseif( false !== strpos( $provider_url, 'vine.co' ) ) {
 		$provider_name = 'vine';
-	} elseif( false !== strpos( $providerURL, 'facebook.com' ) ) {
+	} elseif( false !== strpos( $provider_url, 'facebook.com' ) ) {
 		$provider_name = 'facebook';
 	}
 

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -4,7 +4,7 @@
  * Description: Add support for Instant Articles for Facebook to your WordPress site.
  * Author: Automattic, Dekode, Facebook
  * Author URI: https://vip.wordpress.com/plugins/instant-articles/
- * Version: 3.3.1
+ * Version: 3.3.2
  * Text Domain: instant-articles
  * License: GPLv2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -61,7 +61,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 
 	defined( 'ABSPATH' ) || die( 'Shame on you' );
 
-	define( 'IA_PLUGIN_VERSION', '3.3.1' );
+	define( 'IA_PLUGIN_VERSION', '3.3.2' );
 	define( 'IA_PLUGIN_PATH_FULL', __FILE__ );
 	define( 'IA_PLUGIN_PATH', plugin_basename( __FILE__ ) );
 	define( 'IA_PLUGIN_FILE_BASENAME', pathinfo( __FILE__, PATHINFO_FILENAME ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: trrine, olethomas, bjornjohansen, dekode, automattic, facebook
 Tags: instant articles, facebook, mobile
 Requires at least: 4.3
 Tested up to: 4.6
-Stable tag: 3.3.1
+Stable tag: 3.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/release.sh
+++ b/release.sh
@@ -16,8 +16,6 @@ ${green}Usage:${reset}
   ${blue}${me} [-hvs] [-c <command>] [version]${reset}
 
 ${green}Arguments:${reset}
-  release      - Creates a GitHub released based on existing version tag
-  bump_version - Creates a new version tag
   version      - The target version (ex: 3.2.1)
 
 ${green}Options:${reset}
@@ -27,6 +25,9 @@ ${green}Options:${reset}
   -c <command>  Runs only a single command. Possible commands are:
                   - bump_version: generate a new version tag on the repository
                   - release: release a new version on GitHub
+                  - publish: publishes the target version to the WordPress 
+                             plugin repository
+
 
 ${green}Examples:${reset}
 

--- a/release.sh
+++ b/release.sh
@@ -369,6 +369,7 @@ function release {
 
   message "Creating binary file"
   run composer install
+  run composer update
   run zip -qr facebook-instant-articles-wp.zip .
 
   message "Uploading binary for release..."
@@ -421,7 +422,8 @@ function publish {
   tmp_dir=$(mktemp -d)
 
   message "Updating composer dependencies"
-  composer install
+  run composer install
+  run composer update
 
   message "Checking out SVN repository..."
   run cd $tmp_dir

--- a/wizard/class-instant-articles-option-publishing.php
+++ b/wizard/class-instant-articles-option-publishing.php
@@ -54,6 +54,22 @@ class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
 			'default' => false,
 			'checkbox_label' => 'Publish articles containing warnings',
 		),
+
+		'likes_on_media' => array(
+			'label' => 'Likes',
+			'description' => 'With this option enabled, any video, image and slideshow will have the like action enabled by default.',
+			'render' => 'checkbox',
+			'default' => false,
+			'checkbox_label' => 'Enable like action on media elements by default',
+		),
+
+		'comments_on_media' => array(
+			'label' => 'Comments',
+			'description' => 'With this option enabled, any video, image and slideshow will have the comments enabled by default.',
+			'render' => 'checkbox',
+			'default' => false,
+			'checkbox_label' => 'Enable comments on media elements by default',
+		),
 	);
 
 	/**

--- a/wizard/class-instant-articles-option-publishing.php
+++ b/wizard/class-instant-articles-option-publishing.php
@@ -57,18 +57,18 @@ class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
 
 		'likes_on_media' => array(
 			'label' => 'Likes',
-			'description' => 'With this option enabled, any video, image and slideshow will have the like action enabled by default.',
+			'description' => 'With this option enabled, any image or video will have the like action enabled by default.',
 			'render' => 'checkbox',
 			'default' => false,
-			'checkbox_label' => 'Enable like action on media elements by default',
+			'checkbox_label' => 'Enable like action on images and videos by default',
 		),
 
 		'comments_on_media' => array(
 			'label' => 'Comments',
-			'description' => 'With this option enabled, any video, image and slideshow will have the comments enabled by default.',
+			'description' => 'With this option enabled, any image or video will have the comments enabled by default.',
 			'render' => 'checkbox',
 			'default' => false,
-			'checkbox_label' => 'Enable comments on media elements by default',
+			'checkbox_label' => 'Enable comments on images and videos by default',
 		),
 	);
 

--- a/wizard/class-instant-articles-option-styles.php
+++ b/wizard/class-instant-articles-option-styles.php
@@ -28,6 +28,14 @@ class Instant_Articles_Option_Styles extends Instant_Articles_Option {
 			'default' => 'default',
 		),
 
+		'rtl_enabled' => array(
+			'label' => 'Right-to-Left Publishing',
+			'render' => 'checkbox',
+			'default' => false,
+			'description' => 'Body text will read right to left for all articles.',
+			'checkbox_label' => 'Enable Right-to-Left (RTL) publishing',
+		),
+
 	);
 
 	/**


### PR DESCRIPTION
This PR:

* [x] Adds configuration for likes and comments
* [x] Makes easier to enable likes + comments without any coding

Relates to https://github.com/facebook/facebook-instant-articles-sdk-php/pull/195

Fixes #36 and #340 
