### PR TITLE
Apester plugin support

### DIFF
--- a/compat.php
+++ b/compat.php
@@ -47,7 +47,6 @@ include( dirname( __FILE__ ) . '/compat/class-instant-articles-playbuzz.php' );
 $playbuzz = new Instant_Articles_Playbuzz;
 $playbuzz->init();
 
-
 // Load support for Apester's plugin Medias
 include( dirname( __FILE__ ) . '/compat/class-instant-articles-apester.php' );
 $apester = new Instant_Articles_Apester;

--- a/compat.php
+++ b/compat.php
@@ -46,3 +46,9 @@ if ( function_exists( 'get_the_image' ) ) {
 include( dirname( __FILE__ ) . '/compat/class-instant-articles-playbuzz.php' );
 $playbuzz = new Instant_Articles_Playbuzz;
 $playbuzz->init();
+
+
+// Load support for Apester's plugin Medias
+include( dirname( __FILE__ ) . '/compat/class-instant-articles-apester.php' );
+$apester = new Instant_Articles_Apester;
+$apester->init();

--- a/compat/apester-rules-configuration.json
+++ b/compat/apester-rules-configuration.json
@@ -1,7 +1,7 @@
 {
   "rules": [{
     "class": "IgnoreRule",
-    "selector": "//p/script[contains(@src,'apester')]"
+    "selector": "//script[contains(@src,'apester')]"
   }, {
     "class": "InteractiveRule",
     "selector": "div.apester-media",

--- a/compat/apester-rules-configuration.json
+++ b/compat/apester-rules-configuration.json
@@ -1,0 +1,21 @@
+{
+  "rules": [{
+    "class": "IgnoreRule",
+    "selector": "//p/script[contains(@src,'apester')]"
+  }, {
+    "class": "InteractiveRule",
+    "selector": "div.apester-media",
+    "properties": {
+      "interactive.iframe": {
+        "type": "multiple",
+        "children": [{
+          "type": "fragment",
+          "fragment": "<script type='text/javascript' src='//static.apester.com/js/sdk/latest/apester-sdk.min.js'></script>"
+        }, {
+          "type": "element",
+          "selector": "div.apester-media"
+        }]
+      }
+    }
+  }]
+}

--- a/compat/class-instant-articles-apester.php
+++ b/compat/class-instant-articles-apester.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Support class for Apester
+ *
+ * @since 3.3.2
+ *
+ */
+class Instant_Articles_Apester {
+
+	/**
+	 * Init the compat layer
+	 *
+	 */
+	function init() {
+		add_filter( 'instant_articles_transformer_rules_loaded', array( 'Instant_Articles_Apester', 'transformer_loaded' ) );
+	}
+
+	public static function transformer_loaded( $transformer ) {
+		// Appends more rules to transformer
+		$file_path = plugin_dir_path( __FILE__ ) . 'apester-rules-configuration.json';
+		$configuration = file_get_contents( $file_path );
+		$transformer->loadRules( $configuration );
+
+		return $transformer;
+	}
+}


### PR DESCRIPTION
This PR:

* [x] Adds compat support for the Apester plugin
* [x] Adds setup rules for the Apester markup
* [x] Enables these rules by default - not dependant on Apester plugin installation state
