### PR TITLE
Extracted anonymous inline function

### DIFF
--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -12,13 +12,19 @@
  * @package default
  */
 
+/**
+* Prints error about incompatible version. Extracted as function issue: #390
+*
+* @since 3.3.4
+*/
+function show_version_incompatible_warning() {
+	echo '<div class="error"><p>' .
+		esc_html__( 'Instant Articles for WP requires PHP 5.4 to function properly. Please upgrade PHP or deactivate Instant Articles for WP.', 'instant-articles' ) . '</p></div>';
+}
 if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	add_action(
 		'admin_notices',
-		function () {
-			echo '<div class="error"><p>' .
-				esc_html__( 'Instant Articles for WP requires PHP 5.4 to function properly. Please upgrade PHP or deactivate Instant Articles for WP.', 'instant-articles' ) . '</p></div>';
-		}
+		'show_version_incompatible_warning'
 	);
 	return;
 } else {


### PR DESCRIPTION
This PR:

* [x] Removed an inline anonymous function to make it compatible with older PHP + WP versions

Fixes #390
