### PR TITLE
Switch on/off configuration for enabling comments/likes by default

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -680,6 +680,19 @@ class Instant_Articles_Post {
 
 		$this->set_appearance_from_settings();
 
+		// This block sets as default likes and/or comments based on the configuration setup,
+		// and call $transformer->transform will consider the defaults before building the Elements
+		//
+		// Warning: if you are using pthreads or any other multithreaded engine, consider replicating this to all processes.
+		if ( isset( $settings_publishing[ 'likes_on_media' ] ) ) {
+			Image::setDefaultLikeEnabled( $settings_publishing[ 'likes_on_media' ] );
+			Video::setDefaultLikeEnabled( $settings_publishing[ 'likes_on_media' ] );
+		}
+		if ( isset( $settings_publishing[ 'comments_on_media' ] ) ) {
+			Image::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
+			Video::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
+		}
+
 		$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );
 
 		$this->add_ads_from_settings();

--- a/wizard/class-instant-articles-option-publishing.php
+++ b/wizard/class-instant-articles-option-publishing.php
@@ -54,6 +54,22 @@ class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
 			'default' => false,
 			'checkbox_label' => 'Publish articles containing warnings',
 		),
+
+		'likes_on_media' => array(
+			'label' => 'Likes',
+			'description' => 'With this option enabled, any image or video will have the like action enabled by default.',
+			'render' => 'checkbox',
+			'default' => false,
+			'checkbox_label' => 'Enable like action on images and videos by default',
+		),
+
+		'comments_on_media' => array(
+			'label' => 'Comments',
+			'description' => 'With this option enabled, any image or video will have the comments enabled by default.',
+			'render' => 'checkbox',
+			'default' => false,
+			'checkbox_label' => 'Enable comments on images and videos by default',
+		),
 	);
 
 	/**


### PR DESCRIPTION
- [x] Adds configuration for likes and comments
- [x] Makes easier to enable likes + comments without any coding

Relates to https://github.com/facebook/facebook-instant-articles-sdk-php/pull/195
Replaces #605 

Fixes #36 and #340
