### PR TITLE
Allow for alternative file path for json rules

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -602,6 +602,7 @@ class Instant_Articles_Post {
 
 		// Initialize transformer
 		$file_path = plugin_dir_path( __FILE__ ) . 'rules-configuration.json';
+		$file_path = apply_filters('instant_articles_transformer_rules_configuration_json_file_path', $file_path );
 		$configuration = file_get_contents( $file_path );
 
 		$transformer = new Transformer();

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -602,7 +602,7 @@ class Instant_Articles_Post {
 
 		// Initialize transformer
 		$file_path = plugin_dir_path( __FILE__ ) . 'rules-configuration.json';
-		$file_path = apply_filters('instant_articles_transformer_rules_configuration_json_file_path', $file_path );
+		$file_path = apply_filters( 'instant_articles_transformer_rules_configuration_json_file_path', $file_path );
 		$configuration = file_get_contents( $file_path );
 
 		$transformer = new Transformer();


### PR DESCRIPTION
Added ability to set own file path for the rules-configuration.json file so that developers can specify their own json rules and not run the risk of updates to this plugin effecting the way their transformed instant articles behave.

This PR:

* [x] Adds a new filter for setting up the rules-configuration.json ('instant_articles_transformer_rules_configuration_json_file_path')
