### PR TITLE
fix merge damage

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -636,11 +636,7 @@ class Instant_Articles_Post {
 
 		$title = $this->get_the_title();
 		if ( $title ) {
-			$document = new DOMDocument();
-			libxml_use_internal_errors(true);
-			$document->loadHTML( '<?xml encoding="' . $blog_charset . '" ?><h1>' . $title . '</h1>' );
-			libxml_use_internal_errors(false);
-			$transformer->transform( $header, $document );
+			$transformer->transformString( $header, '<h1>' . $title . '</h1>', $blog_charset );
 		}
 
 		if ( $this->has_subtitle() ) {


### PR DESCRIPTION
as @yssk22 commented in #428, the refactored code has been reverted back by mistake, and it result in garbled MB characters in title.

This PR:

* [x] puts back the code that has mistakenly been reverted

Relates to #428
