### PR TITLE
Bring in global variables for current blog and post

### DIFF
--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -22,6 +22,7 @@ function wpcom_fbia_remove_stats_pixel() {
 add_action( 'template_redirect', 'wpcom_fbia_remove_stats_pixel' );
 
 function wpcom_fbia_add_stats_pixel( $ia_post ) {
+	global $current_blog, $post;
 
 	// Get the IA article.
 	$instant_article = $ia_post->instant_article;


### PR DESCRIPTION
Bring in global variables for current blog and post. Fixes an undefined variable error message.

Noticed in PHP 7.1.