### PR TITLE
Fix wp_is_post_autosave() parameter value

### DIFF
--- a/class-instant-articles-publisher.php
+++ b/class-instant-articles-publisher.php
@@ -40,7 +40,7 @@ class Instant_Articles_Publisher {
 	public static function submit_article( $post_id, $post ) {
 
 		// Don't process if this is just a revision or an autosave.
-		if ( wp_is_post_revision( $post ) || wp_is_post_autosave( $post ) ) {
+		if ( wp_is_post_revision( $post ) || wp_is_post_autosave( $post->ID ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR:
Fixes #

For wp_is_post_autosave() to works, it requires $post->ID and not just $post object.
Reference: https://codex.wordpress.org/Function_Reference/wp_is_post_autosave
