### PR TITLE
Fix "Empty string supplied as input" bug

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -690,7 +690,7 @@ class Instant_Articles_Post {
 			Video::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
 		}
 
-		if ( !empty( $this->get_the_content() ) ) {
+		if ( '' == $this->get_the_content() ) {
 			$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );
 		}
 

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -18,6 +18,8 @@ use Facebook\InstantArticles\Elements\Video;
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Footer;
 use Facebook\InstantArticles\Transformer\Transformer;
+use Facebook\InstantArticles\Validators\Type;
+
 /**
  * Class responsible for constructing our content and preparing it for rendering
  *
@@ -691,7 +693,7 @@ class Instant_Articles_Post {
 		}
 		
 		$the_content = $this->get_the_content();
-		if ( '' != $the_content ) {
+		if (!Type::isTextEmpty($the_content)) {
 			$transformer->transformString( $this->instant_article, $the_content, get_option( 'blog_charset' ) );
 		}
 

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -690,7 +690,7 @@ class Instant_Articles_Post {
 			Video::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
 		}
 
-		if ( '' == $this->get_the_content() ) {
+		if ( '' != $this->get_the_content() ) {
 			$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );
 		}
 

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -690,7 +690,9 @@ class Instant_Articles_Post {
 			Video::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
 		}
 
-		$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );
+		if ( !empty( $this->get_the_content() ) ) {
+			$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );
+		}
 
 		$this->add_ads_from_settings();
 		$this->add_analytics_from_settings();

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -689,9 +689,10 @@ class Instant_Articles_Post {
 			Image::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
 			Video::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
 		}
-
-		if ( '' != $this->get_the_content() ) {
-			$transformer->transformString( $this->instant_article, $this->get_the_content(), get_option( 'blog_charset' ) );
+		
+		$the_content = $this->get_the_content();
+		if ( '' != $the_content ) {
+			$transformer->transformString( $this->instant_article, $the_content, get_option( 'blog_charset' ) );
 		}
 
 		$this->add_ads_from_settings();


### PR DESCRIPTION
This PR:

Fixes #
Fix `PHP Warning:  DOMDocument::loadHTML(): Empty string supplied as input`, by verifying the content and making sure if it is empty, do not `transformString`.

Automattic/facebook-instant-articles-wp#628