### PR TITLE
allow markups in footer/copyright

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -17,6 +17,7 @@ use Facebook\InstantArticles\Elements\Image;
 use Facebook\InstantArticles\Elements\Video;
 use Facebook\InstantArticles\Elements\Caption;
 use Facebook\InstantArticles\Elements\Footer;
+use Facebook\InstantArticles\Elements\Small;
 use Facebook\InstantArticles\Transformer\Transformer;
 /**
  * Class responsible for constructing our content and preparing it for rendering
@@ -879,9 +880,12 @@ class Instant_Articles_Post {
 		}
 
 		if ( isset( $settings['copyright'] ) && ! empty( $settings['copyright'] ) ) {
-			$this->instant_article->withFooter(
-				Footer::create()->withCopyright( $settings['copyright'] )
-			);
+			$footer = Footer::create();
+			$this->transformer->transformString(
+				$footer,
+				'<small>' . $settings['copyright'] . '</small>',
+				get_option( 'blog_charset' ) );
+			$this->instant_article->withFooter( $footer );
 		}
 
 		if ( isset( $settings['rtl_enabled'] ) ) {

--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -27,6 +27,9 @@
         "class": "ParagraphRule",
         "selector": "p"
     }, {
+        "class": "FooterSmallRule",
+        "selector": "small"
+    }, {
         "class": "LineBreakRule",
         "selector": "br"
     }, {

--- a/wizard/class-instant-articles-option-styles.php
+++ b/wizard/class-instant-articles-option-styles.php
@@ -31,7 +31,7 @@ class Instant_Articles_Option_Styles extends Instant_Articles_Option {
 		'copyright' => array(
 			'label' => 'Copyright',
 			'default' => '',
-			'description' => 'The copyright details for your articles. Note: No markup tags can be used in this field. <a href="https://developers.facebook.com/docs/instant-articles/reference/footer" target="_blank">Learn more about Footer in Instant Articles</a>.',
+			'description' => 'The copyright details for your articles. Note: Some inline html tags can be used in this field. <a href="https://developers.facebook.com/docs/instant-articles/reference/footer" target="_blank">Learn more about Footer in Instant Articles</a>.',
 		),
 
 		'rtl_enabled' => array(


### PR DESCRIPTION
This PR:
- adds capability to markups in footer
- closes #619
- depends on facebook/facebook-instant-articles-sdk-php/pull/198

## plugin setting
![image](https://cloud.githubusercontent.com/assets/81522/24193322/3fc3c514-0f35-11e7-93f2-e65239b39f73.png)

## footer with markup
![image](https://cloud.githubusercontent.com/assets/81522/24193547/fd1aa48e-0f35-11e7-821f-1a9e911c2cd8.png)
