### PR TITLE
Improvements to "Submit for Review" section during plugin installation

### DIFF
--- a/wizard/class-instant-articles-wizard-review-submission.php
+++ b/wizard/class-instant-articles-wizard-review-submission.php
@@ -33,7 +33,8 @@ class Instant_Articles_Wizard_Review_Submission {
 		return wp_get_recent_posts(
 		 	array(
 				'numberposts' => min( self::MIN_ARTICLES, 100 ),
-				'post_type' => $post_types
+				'post_type' => $post_types,
+				'post_status' => 'publish',
 			),
 			'OBJECT'
 		);

--- a/wizard/class-instant-articles-wizard.php
+++ b/wizard/class-instant-articles-wizard.php
@@ -308,12 +308,17 @@ class Instant_Articles_Wizard {
 						return $instant_articles_post;
 					}, $articles_for_review );
 
-					// Filter articles with warnings and not forced
-					$instant_articles_with_warnings = array_filter( $instant_articles_for_review, function ( $article ) {
+					// Create two arrays: one with articles that contain warnings and are not foced, and one for articles that are valid
+					foreach ($instant_articles_for_review as $article) {
+						$instant_articles_post = new Instant_Articles_Post( $article );
 						$has_warnings = ( count( $article->transformer->getWarnings() ) > 0 );
 						$force_submit = get_post_meta( $article->get_the_id(), Instant_Articles_Publisher::FORCE_SUBMIT_KEY, true );
-						return $has_warnings && ! $force_submit;
-					} );
+						if ($has_warnings && ! $force_submit) {
+							$instant_articles_with_warnings[] = $article;
+						} else {
+							$instant_articles_valid[] = $article;
+						}
+					}
 				}
 			}
 			// ----------------------------------

--- a/wizard/templates/review-submission-template.php
+++ b/wizard/templates/review-submission-template.php
@@ -60,14 +60,21 @@ switch ( $review_submission_status ) :
 							</p>
 							<p>
 								The plugin tried to automatically transform your last <?php echo esc_html( Instant_Articles_Wizard_Review_Submission::MIN_ARTICLES ); ?>
-								posts into Instant Articles as a sample to submit for review, but some of these posts contained elements the plugin didn't know how to convert.
+								posts into Instant Articles as a sample to submit for review.
 							</p>
-							<p>
-								Before submitting for review, you'll need to handle the warnings on these articles by looking at the "Instant Articles" box on the post edit screen:
+							<?php if ( count($instant_articles_valid) > 0 ) : ?>
+								<p>The following posts were successfully transformed:</p>
+								<ul>
+									<?php foreach ($instant_articles_valid as $article): ?>
+										<li><?php edit_post_link( empty($article->get_the_title()) ? "(no title)" : $article->get_the_title(), '- ', ' <b>[VALID]</b>', $article->get_the_id() ); ?> </li>
+								<?php endforeach; ?>
+							</ul>
+							<?php endif; ?>
+							<p>However, some of these posts contained elements the plugin didn't know how to convert. Before submitting for review, you'll need to handle the warnings on these articles by looking at the "Instant Articles" box on the post edit screen:
 							</p>
 							<ul>
 								<?php foreach ($instant_articles_with_warnings as $article): ?>
-									<li><?php edit_post_link( $article->get_the_title(), '- ', '', $article->get_the_id() ); ?> </li>
+									<li><?php edit_post_link( empty($article->get_the_title()) ? "(no title)" : $article->get_the_title(), '- ', '', $article->get_the_id() ); ?> </li>
 								<?php endforeach; ?>
 							</ul>
 							<p>


### PR DESCRIPTION
This PR:

* [x] Shows the status of all 5 articles being automatically converted for review
* [x] Only take into account posts that have status 'publish'
* [x] Prevents posts with no title from not being editable  

Follows #

Relates to #

Fixes #698 

![image](https://user-images.githubusercontent.com/960935/27512511-a2949098-593a-11e7-829b-2abacceaeb27.png)

