### PR TITLE
Do not process non-post pages. Fixes #707

### DIFF
--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -366,7 +366,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 		$post = get_post();
 
 		// If there's no current post, return
-		if (! $post) {
+		if ( ! $post ) {
 			return;
 		}
 

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -364,6 +364,12 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	 */
 	function inject_ia_markup_meta_tag() {
 		$post = get_post();
+
+		// If there's no current post, return
+		if (! $post) {
+			return;
+		}
+
 		// Transform the post to an Instant Article.
 		$adapter = new Instant_Articles_Post( $post );
 		if ( $adapter->should_submit_post() ) {


### PR DESCRIPTION
This PR prevents the plugin from trying to inject the meta-tag on non-post pages, which was causing NOTICES to be shown on the debug log.

Fixes #707 
