### PR TITLE
Add cache layer for avoiding transforming the article at page render

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -909,8 +909,12 @@ class Instant_Articles_Post {
 			return false;
 		}
 
-		$cache = get_post_meta( $this->get_the_id(), 'should_submit_post_content', true );
+		// This post meta is a cache on the calculations made to decide if
+		// a post is in good state to be converted to an Instant Article or not
+		$cache = get_post_meta( $this->get_the_id(), '_should_submit_post_content', true );
 		if ( $cache ) {
+			// We use 'yes' or 'no' to avoid booleans because
+			// get_post_meta() returns false when the key is not found
 			return ( $cache === 'yes' );
 		}
 
@@ -921,7 +925,7 @@ class Instant_Articles_Post {
 		// WordPress does not load the content field from DB for performance reasons. In this case, articles
 		// will be empty here, despite of them actually having content.
 		if ( count( $instant_article->getChildren() ) === 0 || ! $instant_article->getHeader() || ! $instant_article->getHeader()->getTitle() ) {
-			update_post_meta( $this->get_the_id(), 'should_submit_post_content', 'no' );
+			update_post_meta( $this->get_the_id(), '_should_submit_post_content', 'no' );
 			return false;
 		}
 
@@ -932,11 +936,11 @@ class Instant_Articles_Post {
 		  && ( ! isset( $publishing_settings[ 'publish_with_warnings' ] ) || ! $publishing_settings[ 'publish_with_warnings' ] )
 			&& ( ! $force_submit )
 			) {
-			update_post_meta( $this->get_the_id(), 'should_submit_post_content', 'no' );
+			update_post_meta( $this->get_the_id(), '_should_submit_post_content', 'no' );
 			return false;
 		}
 
-		update_post_meta( $this->get_the_id(), 'should_submit_post_content', 'yes' );
+		update_post_meta( $this->get_the_id(), '_should_submit_post_content', 'yes' );
 		return true;
 	 }
 

--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -956,8 +956,6 @@ class Instant_Articles_Post {
 			return false;
 		}
 
-		$instant_article = $this->to_instant_article();
-
 		// Skip empty articles or articles missing title.
 		// This is important because the save_post action is also triggered by bulk updates, but in this case
 		// WordPress does not load the content field from DB for performance reasons. In this case, articles

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -452,7 +452,9 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	add_action( 'save_post', 'rescrape_article', 999, 2 );
 
 	function invalidate_should_submit_post_content_cache( $post_id, $post ) {
-		delete_post_meta( $this->get_the_id(), 'should_submit_post_content' );
+		// This post meta is a cache on the calculations made to decide if
+		// a post is in good state to be converted to an Instant Article or not
+		delete_post_meta( $this->get_the_id(), '_should_submit_post_content' );
 	}
 	add_action( 'save_post', 'invalidate_should_submit_post_content_cache', 10, 2 );
 

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -451,11 +451,24 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	}
 	add_action( 'save_post', 'rescrape_article', 999, 2 );
 
-	function invalidate_should_submit_post_content_cache( $post_id, $post ) {
-		// This post meta is a cache on the calculations made to decide if
+	function invalidate_post_transformation_info_cache( $post_id, $post ) {
+		// These post metas are caches on the calculations made to decide if
 		// a post is in good state to be converted to an Instant Article or not
-		delete_post_meta( $this->get_the_id(), '_should_submit_post_content' );
+		delete_post_meta( $this->get_the_id(), '_has_warnings_after_transformation' );
+		delete_post_meta( $this->get_the_id(), '_is_empty_after_transformation' );
 	}
-	add_action( 'save_post', 'invalidate_should_submit_post_content_cache', 10, 2 );
+	add_action( 'save_post', 'invalidate_post_transformation_info_cache', 10, 2 );
+
+	// We also need to invalidate the transformation caches when the option containing
+	// the custom transformer rules is updated
+	function invalidate_all_posts_transformation_info_cache( $option ) {
+		if ( $option === Instant_Articles_Option_Publishing::OPTION_KEY ) {
+			// These post metas are caches on the calculations made to decide if
+			// a post is in good state to be converted to an Instant Article or not
+			delete_post_meta_by_key( '_has_warnings_after_transformation' );
+			delete_post_meta_by_key( '_is_empty_after_transformation' );
+		}
+	}
+	add_action( 'updated_option', 'invalidate_all_posts_transformation_info_cache', 10, 1 );
 
 }

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -451,5 +451,9 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	}
 	add_action( 'save_post', 'rescrape_article', 999, 2 );
 
+	function invalidate_should_submit_post_content_cache( $post_id, $post ) {
+		delete_post_meta( $this->get_the_id(), 'should_submit_post_content' );
+	}
+	add_action( 'save_post', 'invalidate_should_submit_post_content_cache', 10, 2 );
 
 }

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -454,8 +454,8 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	function invalidate_post_transformation_info_cache( $post_id, $post ) {
 		// These post metas are caches on the calculations made to decide if
 		// a post is in good state to be converted to an Instant Article or not
-		delete_post_meta( $this->get_the_id(), '_has_warnings_after_transformation' );
-		delete_post_meta( $this->get_the_id(), '_is_empty_after_transformation' );
+		delete_post_meta( $post_id, '_has_warnings_after_transformation' );
+		delete_post_meta( $post_id, '_is_empty_after_transformation' );
 	}
 	add_action( 'save_post', 'invalidate_post_transformation_info_cache', 10, 2 );
 


### PR DESCRIPTION
This PR address the 10% performance regression reported on the WordPress plugin support forum. 

I'm adding a cache layer using a simple post meta to avoid transforming the article to Instant Article at every page render for calculating whether it's a valid IA (which we use to decide whether to include the ia-markup meta tag or not).
