### PR TITLE
(wizard) Update wording about AMP markup gen

### DIFF
--- a/wizard/class-instant-articles-option-amp.php
+++ b/wizard/class-instant-articles-option-amp.php
@@ -28,7 +28,7 @@ class Instant_Articles_Option_AMP extends Instant_Articles_Option {
 
 		Instant_Articles_AMP_Markup::SETTING_AMP_MARKUP => array(
 			'label' => 'Enable Markup (experimental)',
-			'description' => 'With this option enabled, posts will also be available in AMP markup',
+			'description' => 'With this option enabled, posts will also be available in AMP markup. You can check the generated markup by appending "?amp_markup=1" to a post URL.',
 			'render' => 'checkbox',
 			'default' => false,
 			'checkbox_label' => 'Enable AMP markup generation',

--- a/wizard/class-instant-articles-option-amp.php
+++ b/wizard/class-instant-articles-option-amp.php
@@ -28,7 +28,7 @@ class Instant_Articles_Option_AMP extends Instant_Articles_Option {
 
 		Instant_Articles_AMP_Markup::SETTING_AMP_MARKUP => array(
 			'label' => 'Enable Markup (experimental)',
-			'description' => 'With this option enabled, posts will also be available in AMP markup. You can check the generated markup by appending "?amp_markup=1" to a post URL.',
+			'description' => 'With this option enabled, posts will also be available in AMP markup. The generated mark-up can be accessed by adding ?amp_markup=1 to the URL of a post.',
 			'render' => 'checkbox',
 			'default' => false,
 			'checkbox_label' => 'Enable AMP markup generation',


### PR DESCRIPTION
This PR:

* [x] Helps the user to get started with AMP markup generation, by pointing out what to do to check the generated markup.

Fixes #734 
