### PR TITLE
Add label definitions

### DIFF
--- a/LABELS.md
+++ b/LABELS.md
@@ -1,0 +1,19 @@
+## Labels
+### bug
+A general bug in the plugin that needs to be fixed
+### compat: wordpress.com
+An incompatibility between the plugin and wordpress.com
+### compat: 3rd party
+An incompatibility between the plugin and another 3rd party plugin
+### documentation
+Incomplete or misleading information in the official documentation
+### enhancement/feature request
+Something that is currently not supported but requested by one or more users
+### help wanted
+An issue for which the contributors look for help from the community
+### missing rule
+A transformation rule that should be added
+### more info needed
+The author of the issue has provided insufficient information
+### transformation
+An bug in the transformation which is not related to a missing rule


### PR DESCRIPTION
This PR:
Adds a file which describes the meaning of the labels that we use so we can
* Consistently use the labels
* Help our users understand why their issue was tagged with certain labels