### PR TITLE
Change meta box and readme so user doesn't think IAs are actually submitted to Facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Facebook requires a minimum number of articles in your feed before they will rev
 More likely than not, this is because there is markup in the body of your post that is not mapped to a recognized Instant Article component. On the “Edit Post” screen for your post, look for additional information about the *transformed* output shown within the **Facebook Instant Articles** module located at the bottom of the screen.
 
 **Why doesn't my post appear in the list of Instant Articles in the publisher tools?**
-In order for your post to be imported you have to share it on your page first.
-
+Your posts are imported to your library when they are shared on Facebook for the first time.
+ 
+Alternatively, you can trigger a manual scrape by pasting your URL on our [Share Debugger](http://developers.facebook.com/tools/debug)
 **In the Instant Articles module for my post, what does the “This post was transformed into an Instant Article with some warnings” message mean?**
 
 When transforming your post into an Instant Article, this plugin will show warnings when it encounters content which might not be valid when published to Facebook. When you see this message, it is recommended to resolve each warning individually.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can propose popular transformer rules to be included in the plugin by [sugge
 
 **How do I post articles to Instant Articles after plugin is installed?**
 
-You can re-publish existing articles (simply edit + save) or post new articles in order to make them available as Instant Articles. After you have 5 articles added and shared on Facebook, you will be able to submit them for review.
+In order to import your posts to your Instant Articles library on Facebook you need to either share them on your page or use the [Sharing Debugger](https://developers.intern.facebook.com/tools/debug/sharing/) to scrape them. After you have 10 articles imported, you will be able to submit them for review.
 
 **How do I change the feed slug/URL if I'm using the RSS integration?**
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Facebook requires a minimum number of articles in your feed before they will rev
 
 More likely than not, this is because there is markup in the body of your post that is not mapped to a recognized Instant Article component. On the “Edit Post” screen for your post, look for additional information about the *transformed* output shown within the **Facebook Instant Articles** module located at the bottom of the screen.
 
+**Why doesn't my post appear in the list of Instant Articles in the publisher tools?**
+In order for your post to be imported you have to share it on your page first.
+
 **In the Instant Articles module for my post, what does the “This post was transformed into an Instant Article with some warnings” message mean?**
 
 When transforming your post into an Instant Article, this plugin will show warnings when it encounters content which might not be valid when published to Facebook. When you see this message, it is recommended to resolve each warning individually.
@@ -57,7 +60,7 @@ You can propose popular transformer rules to be included in the plugin by [sugge
 
 **How do I post articles to Instant Articles after plugin is installed?**
 
-You can re-publish existing articles (simply edit + save) or post new articles in order to submit them to Instant Articles. After you have 10 articles added, you will be able to submit them for review.
+You can re-publish existing articles (simply edit + save) or post new articles in order to make them available as Instant Articles. After you have 5 articles added and shared, you will be able to submit them for review.
 
 **How do I change the feed slug/URL if I'm using the RSS integration?**
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can propose popular transformer rules to be included in the plugin by [sugge
 
 **How do I post articles to Instant Articles after plugin is installed?**
 
-You can re-publish existing articles (simply edit + save) or post new articles in order to make them available as Instant Articles. After you have 5 articles added and shared, you will be able to submit them for review.
+You can re-publish existing articles (simply edit + save) or post new articles in order to make them available as Instant Articles. After you have 5 articles added and shared on Facebook, you will be able to submit them for review.
 
 **How do I change the feed slug/URL if I'm using the RSS integration?**
 

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -22,7 +22,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-yes"></span>
-		This post will be available as an Instant Article.
+		This post will be available as Instant Article.
 	</b>
 </p>
 <hr>
@@ -30,7 +30,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-no-alt"></span>
-		This post will not be submitted to Instant Articles due to a rule created in your site.
+		This post will not be available as Instant Article due to a rule created in your site.
 	</b>
 </p>
 <hr>
@@ -38,7 +38,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-media-document"></span>
-		This post will be submitted to Instant Articles once it is published.
+		This post will be available as Instant Article once it is published.
 	</b>
 </p>
 <hr>
@@ -46,7 +46,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-no-alt"></span>
-		This post will not be submitted to Instant Articles because it is missing a title.
+		This post will not be available as Instant Article because it is missing a title.
 	</b>
 </p>
 <hr>
@@ -54,7 +54,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-no-alt"></span>
-		This post will not be submitted to Instant Articles because it is missing content.
+		This post will not be available as Instant Article because it is missing content.
 	</b>
 </p>
 <hr>
@@ -71,7 +71,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-no-alt"></span>
-		This post will not be submitted to Instant Articles because the transformation raised some warnings.
+		This post will not be available as Instant Article because the transformation raised some warnings.
 	</b>
 </p>
 <hr>

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -22,7 +22,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-yes"></span>
-		This post will be available as Instant Article once shared on Facebook.
+		This post will be available as Instant Article once it is published and shared on Facebook.
 	</b>
 </p>
 <hr>

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -22,7 +22,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-yes"></span>
-		This post will be available as Instant Article.
+		This post will be available as Instant Article once shared on Facebook.
 	</b>
 </p>
 <hr>
@@ -38,7 +38,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-media-document"></span>
-		This post will be available as Instant Article once it is published.
+		This post will be available as Instant Article once it is published and shared on Facebook.
 	</b>
 </p>
 <hr>

--- a/meta-box/meta-box-template.php
+++ b/meta-box/meta-box-template.php
@@ -22,7 +22,7 @@ use Facebook\InstantArticles\Client\ServerMessage;
 <p>
 	<b>
 		<span class="dashicons dashicons-yes"></span>
-		This post will be available as Instant Article once it is published and shared on Facebook.
+		This post will be available as Instant Article once it is shared on Facebook.
 	</b>
 </p>
 <hr>


### PR DESCRIPTION
Due to the [recent change](https://developers.facebook.com/blog/post/2017/07/18/graph-api-v2.10) in the Graph API articles are not being published to Facebook automatically anymore but rather have to be shared first. See also #791 

This updates all messaging to account for this change.
