### PR TITLE
Display error message if meta box can't be loaded

### DIFF
--- a/meta-box/class-instant-articles-meta-box.php
+++ b/meta-box/class-instant-articles-meta-box.php
@@ -91,26 +91,31 @@ class Instant_Articles_Meta_Box {
 		$ajax_nonce = wp_create_nonce( "instant-articles-force-submit-" . $post_id );
 		$post = get_post( $post_id );
 		$adapter = new Instant_Articles_Post( $post );
-		$article = $adapter->to_instant_article();
-		$canonical_url = $adapter->get_canonical_url();
-		$published = ( 'publish' === $post->post_status );
-		$dev_mode = false;
-		$force_submit = get_post_meta( $post_id, IA_PLUGIN_FORCE_SUBMIT_KEY, true );
-		$instant_articles_should_submit_post_filter = apply_filters( 'instant_articles_should_submit_post', true, $adapter );
 
-		Instant_Articles_Wizard::menu_items();
-		$settings_page_href = Instant_Articles_Wizard::get_url();
+		try {
+			$article = $adapter->to_instant_article();
+			$canonical_url = $adapter->get_canonical_url();
+			$published = ( 'publish' === $post->post_status );
+			$dev_mode = false;
+			$force_submit = get_post_meta( $post_id, IA_PLUGIN_FORCE_SUBMIT_KEY, true );
+			$instant_articles_should_submit_post_filter = apply_filters( 'instant_articles_should_submit_post', true, $adapter );
 
-		$publishing_settings = Instant_Articles_Option_Publishing::get_option_decoded();
-		$publish_with_warnings = isset( $publishing_settings[ 'publish_with_warnings' ] ) ? $publishing_settings[ 'publish_with_warnings' ] : false;
-		$fb_page_settings = Instant_Articles_Option_FB_Page::get_option_decoded();
-		$publishing_settings = Instant_Articles_Option_Publishing::get_option_decoded();
+			Instant_Articles_Wizard::menu_items();
+			$settings_page_href = Instant_Articles_Wizard::get_url();
 
-		$dev_mode = isset( $publishing_settings['dev_mode'] )
-			? ( $publishing_settings['dev_mode'] ? true : false )
-			: false;
+			$publishing_settings = Instant_Articles_Option_Publishing::get_option_decoded();
+			$publish_with_warnings = isset( $publishing_settings[ 'publish_with_warnings' ] ) ? $publishing_settings[ 'publish_with_warnings' ] : false;
+			$fb_page_settings = Instant_Articles_Option_FB_Page::get_option_decoded();
+			$publishing_settings = Instant_Articles_Option_Publishing::get_option_decoded();
 
-		include( dirname( __FILE__ ) . '/meta-box-template.php' );
+			$dev_mode = isset( $publishing_settings['dev_mode'] )
+				? ( $publishing_settings['dev_mode'] ? true : false )
+				: false;
+
+			include( dirname( __FILE__ ) . '/meta-box-template.php' );
+		} catch (Exception $e) {
+			include( dirname( __FILE__ ) . '/meta-box-error.php' );
+		}
 
 		die();
 	}

--- a/meta-box/meta-box-error.php
+++ b/meta-box/meta-box-error.php
@@ -7,4 +7,4 @@
  * @package default
  */
 ?>
-<p>An unkown error occurred while transforming the article. Please verify your rules confgiuration is correct.</p>
+<p>An unkown error occurred while transforming the article. Please verify your rules configuration is correct.</p>

--- a/meta-box/meta-box-error.php
+++ b/meta-box/meta-box-error.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+?>
+<p>An unkown error occurred while transforming the article. Please verify your rules confgiuration is correct.</p>


### PR DESCRIPTION
This PR:
See #770 for initial problem. This PR adds a generic error message that is displayed if the meta box can't be loaded.

fixes #770 
