### PR TITLE
remove article rescrape code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
   "require":
   {
     "php": ">=5.4",
-    "facebook/graph-sdk": "~5.0",
     "apache/log4php": "2.3.0",
     "facebook/facebook-instant-articles-sdk-php": "^1.6.0",
     "facebook/facebook-instant-articles-sdk-extensions-in-php": "^0.1.0",

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -419,44 +419,6 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 
 	Instant_Articles_Wizard::init();
 
-	function rescrape_article( $post_id, $post ) {
-		$adapter = new Instant_Articles_Post( $post );
-		$old_slugs = get_post_meta( $post_id, '_wp_old_slug' );
-		if ( $adapter->should_submit_post() ) {
-			try {
-				$client = Facebook\HttpClients\HttpClientsFactory::createHttpClient( null );
-				$url_encoded = urlencode($adapter->get_canonical_url());
-				$client->send(
-					"https://graph.facebook.com/?id=$url_encoded&scrape=true",
-					'POST',
-					'',
-					array(),
-					60
-				);
-				foreach ( $old_slugs as $slug ) {
-					$clone_post = clone $post;
-					$clone_post->post_name = $slug;
-					$clone_adapter = new Instant_Articles_Post( $clone_post );
-
-					$url_encoded = urlencode($clone_adapter->get_canonical_url());
-					$client->send(
-						"https://graph.facebook.com/?id=$url_encoded&scrape=true",
-						'POST',
-						'',
-						array(),
-						60
-					);
-				}
-			} catch ( Exception $e ) {
-				Logger::getLogger( 'instantarticles-wp-plugin' )->error(
-					'Unable to submit article.',
-					$e->getTraceAsString()
-				);
-			}
-		}
-	}
-	add_action( 'save_post', 'rescrape_article', 999, 2 );
-
 	function invalidate_post_transformation_info_cache( $post_id, $post ) {
 		// These post metas are caches on the calculations made to decide if
 		// a post is in good state to be converted to an Instant Article or not

--- a/meta-box/class-instant-articles-meta-box.php
+++ b/meta-box/class-instant-articles-meta-box.php
@@ -10,7 +10,6 @@
 use Facebook\InstantArticles\Client\Client;
 use Facebook\InstantArticles\Client\InstantArticleStatus;
 use Facebook\InstantArticles\Client\ServerMessage;
-use Facebook\Exceptions\FacebookResponseException;
 
 /**
  * Class responsible for drawing the meta box on the post edit page


### PR DESCRIPTION
This PR:
Removes the code that triggers a rescrape for an article. Due to a recent change in the Graph API this code does not work anymore.
