### PR TITLE
Clarify requirement of site connection in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ More likely than not, this is because there is markup in the body of your post t
 Your posts are imported to your library when they are shared on Facebook for the first time.
  
 Alternatively, you can trigger a manual scrape by pasting your URL on our [Share Debugger](http://developers.facebook.com/tools/debug)
+
+Only Instant Articles with URLs in [domains you have claimed](https://developers.facebook.com/docs/instant-articles/guides/publishertools#connect) will show up in the Publishing Tools section.
 **In the Instant Articles module for my post, what does the “This post was transformed into an Instant Article with some warnings” message mean?**
 
 When transforming your post into an Instant Article, this plugin will show warnings when it encounters content which might not be valid when published to Facebook. When you see this message, it is recommended to resolve each warning individually.
@@ -61,7 +63,7 @@ You can propose popular transformer rules to be included in the plugin by [sugge
 
 **How do I post articles to Instant Articles after plugin is installed?**
 
-In order to import your posts to your Instant Articles library on Facebook you need to either share them on your page or use the [Sharing Debugger](https://developers.intern.facebook.com/tools/debug/sharing/) to scrape them. After you have 10 articles imported, you will be able to submit them for review.
+In order to import your posts to your Instant Articles library on Facebook you need to [Connect Your Site](https://developers.facebook.com/docs/instant-articles/guides/publishertools#connect) first. Then either share your posts on your page or use the [Sharing Debugger](https://developers.intern.facebook.com/tools/debug/sharing/) to scrape them. After you have 10 articles imported, you will be able to submit them for review.
 
 **How do I change the feed slug/URL if I'm using the RSS integration?**
 


### PR DESCRIPTION
This PR adds some clarification to the README file about the requirement of having your domain connected for your articles to show up under Publishing Tools.
