### PR TITLE
Add default rule for Twitter blockquote

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -144,6 +144,23 @@
             }
         }
     }, {
+        "class": "InteractiveRule",
+        "selector" : "blockquote.twitter-tweet",
+        "properties" : {
+            "interactive.iframe" : {
+                "type" : "multiple",
+                "children": [
+                    {
+                        "type": "element",
+                        "selector": "blockquote"
+                    }, {
+                        "type": "next-sibling-element-of",
+                        "selector": "blockquote"
+                    }
+                ]
+            }
+        }
+    }, {
         "class": "IgnoreRule",
         "selector" : "script"
     }, {

--- a/tests/Facebook/InstantArticles/Transformer/wp-ia.xml
+++ b/tests/Facebook/InstantArticles/Transformer/wp-ia.xml
@@ -163,6 +163,15 @@
           <script async="" defer="defer" src="//platform.instagram.com/en_US/embeds.js"></script>
         </iframe>
       </figure>
+      <figure class="op-interactive">
+        <iframe class="no-margin">
+          <blockquote class="twitter-tweet" data-lang="en">
+      <p lang="en" dir="ltr">In an effort to establish stronger ties with the news industry, we're launching The Facebook Journalism Project: <a href="https://t.co/pSxENUU9aa">https://t.co/pSxENUU9aa</a></p>
+      — Facebook (@facebook) <a href="https://twitter.com/facebook/status/819685391355748354?ref_src=twsrc%5Etfw">January 12, 2017</a>
+    </blockquote>
+          <script async="" src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        </iframe>
+      </figure>
       <figure>
         <img src="http://example.com/img.jpg"/>
         <figcaption>blue eyes</figcaption>

--- a/tests/Facebook/InstantArticles/Transformer/wp-rules.json
+++ b/tests/Facebook/InstantArticles/Transformer/wp-rules.json
@@ -139,6 +139,23 @@
         }
     }, {
         "class": "InteractiveRule",
+        "selector" : "blockquote.twitter-tweet",
+        "properties" : {
+            "interactive.iframe" : {
+                "type" : "multiple",
+                "children": [
+                    {
+                        "type": "element",
+                        "selector": "blockquote"
+                    }, {
+                        "type": "next-sibling-element-of",
+                        "selector": "blockquote"
+                    }
+                ]
+            }
+        }
+    }, {
+        "class": "InteractiveRule",
         "selector" : "iframe",
         "properties" : {
             "interactive.url" : {

--- a/tests/Facebook/InstantArticles/Transformer/wp.html
+++ b/tests/Facebook/InstantArticles/Transformer/wp.html
@@ -135,6 +135,11 @@
       </div>
     </blockquote>
     <script async defer src="//platform.instagram.com/en_US/embeds.js"></script>
+    <blockquote class="twitter-tweet" data-lang="en">
+      <p lang="en" dir="ltr">In an effort to establish stronger ties with the news industry, we&#39;re launching The Facebook Journalism Project: <a href="https://t.co/pSxENUU9aa">https://t.co/pSxENUU9aa</a></p>
+      &mdash; Facebook (@facebook) <a href="https://twitter.com/facebook/status/819685391355748354?ref_src=twsrc%5Etfw">January 12, 2017</a>
+    </blockquote>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     <p>
       <figure style="width: 1280px" class="wp-caption alignnone">
         <img src="http://example.com/img.jpg" width="1280" height="740" class />


### PR DESCRIPTION
This PR adds a default rule to transform Twitter Embed codes (those copied from the Twitter website.) This rule is parallel to the existing one we have for Instagram.

Fixes #669
