### PR TITLE
feat(playbuzz): support for the next major playbuzz plugin version

### DIFF
--- a/compat/playbuzz-rules-configuration.json
+++ b/compat/playbuzz-rules-configuration.json
@@ -3,37 +3,37 @@
       "class" : "IgnoreRule",
       "selector": "//p/script[contains(@src,'playbuzz')]"
     }, {
-    "class": "InteractiveRule",
-    "selector" : "div.pb_feed",
-    "properties" : {
-      "interactive.iframe" : {
-        "type" : "multiple",
-        "children": [{
-          "type": "fragment",
-          "fragment": "<script type='text/javascript' src='//cdn.playbuzz.com/widget/feed.js'></script>"
-        }, {
-          "type": "element",
-          "selector": "div.pb_feed"
+      "class": "InteractiveRule",
+      "selector" : "div.pb_feed",
+      "properties" : {
+        "interactive.iframe" : {
+          "type" : "multiple",
+          "children": [{
+              "type": "fragment",
+              "fragment": "<script type='text/javascript' src='//cdn.playbuzz.com/widget/feed.js'></script>"
+            }, {
+              "type": "element",
+              "selector": "div.pb_feed"
+            }
+          ]
         }
-        ]
+      }
+    }, {
+      "class": "InteractiveRule",
+      "selector" : "div.playbuzz",
+      "properties" : {
+        "interactive.iframe" : {
+          "type" : "multiple",
+          "children": [{
+              "type": "fragment",
+              "fragment": "<script type='text/javascript' src='//embed.playbuzz.com/sdk.js'></script>"
+            }, {
+              "type": "element",
+              "selector": "div.playbuzz"
+            }
+          ]
+        }
       }
     }
-  }, {
-    "class": "InteractiveRule",
-    "selector" : "div.playbuzz",
-    "properties" : {
-      "interactive.iframe" : {
-        "type" : "multiple",
-        "children": [{
-          "type": "fragment",
-          "fragment": "<script type='text/javascript' src='//embed.playbuzz.com/sdk.js'></script>"
-        }, {
-          "type": "element",
-          "selector": "div.playbuzz"
-        }
-        ]
-      }
-    }
-  }
   ]
 }

--- a/compat/playbuzz-rules-configuration.json
+++ b/compat/playbuzz-rules-configuration.json
@@ -3,21 +3,37 @@
       "class" : "IgnoreRule",
       "selector": "//p/script[contains(@src,'playbuzz')]"
     }, {
-      "class": "InteractiveRule",
-      "selector" : "div.pb_feed",
-      "properties" : {
-        "interactive.iframe" : {
-          "type" : "multiple",
-          "children": [{
-              "type": "fragment",
-              "fragment": "<script type='text/javascript' src='//cdn.playbuzz.com/widget/feed.js'></script>"
-            }, {
-              "type": "element",
-              "selector": "div.pb_feed"
-            }
-          ]
+    "class": "InteractiveRule",
+    "selector" : "div.pb_feed",
+    "properties" : {
+      "interactive.iframe" : {
+        "type" : "multiple",
+        "children": [{
+          "type": "fragment",
+          "fragment": "<script type='text/javascript' src='//cdn.playbuzz.com/widget/feed.js'></script>"
+        }, {
+          "type": "element",
+          "selector": "div.pb_feed"
         }
+        ]
       }
     }
+  }, {
+    "class": "InteractiveRule",
+    "selector" : "div.playbuzz",
+    "properties" : {
+      "interactive.iframe" : {
+        "type" : "multiple",
+        "children": [{
+          "type": "fragment",
+          "fragment": "<script type='text/javascript' src='//embed.playbuzz.com/sdk.js'></script>"
+        }, {
+          "type": "element",
+          "selector": "div.playbuzz"
+        }
+        ]
+      }
+    }
+  }
   ]
 }


### PR DESCRIPTION
This extra rule support Playbuzz plugin next version,
Playbuzz plugin next version support new Playbuzz embed code v3.0, for match better SEO and removes deprecated Playbuzz code dependencies

This PR: adding the ability to use the new Playbuzz plugin which use the new Playbuzz embed code, 
It won't break the support of the old Playbuzz embed code (v2).

Relates to #895
