### PR TITLE
Enables setup for updating/invalidating articles cache from Facebook scraper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "apache/log4php": "2.3.0",
     "facebook/facebook-instant-articles-sdk-php": "^1.6.0",
     "facebook/facebook-instant-articles-sdk-extensions-in-php": "^0.1.0",
-    "symfony/css-selector": "2.8.*"
+    "symfony/css-selector": "2.8.*",
+    "facebook/graph-sdk": "^5.6"
   },
   "require-dev": {
     "wp-coding-standards/wpcs": "*"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   {
     "php": ">=5.4",
     "apache/log4php": "2.3.0",
-    "facebook/facebook-instant-articles-sdk-php": "^1.6.0",
+    "facebook/facebook-instant-articles-sdk-php": "^1.9.0",
     "facebook/facebook-instant-articles-sdk-extensions-in-php": "^0.1.0",
     "symfony/css-selector": "2.8.*",
     "facebook/graph-sdk": "^5.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9ced014a825a211201d9e61e62b4261b",
-    "content-hash": "2c9df27aa7672a2e915ebf6e6f7c513b",
+    "content-hash": "01d0240e7e9964e8190765878d7e96e9",
     "packages": [
         {
             "name": "apache/log4php",
@@ -35,7 +34,7 @@
                 "logging",
                 "php"
             ],
-            "time": "2012-10-26 09:13:25"
+            "time": "2012-10-26T09:13:25+00:00"
         },
         {
             "name": "facebook/facebook-instant-articles-sdk-extensions-in-php",
@@ -85,32 +84,33 @@
                 "instantarticles",
                 "sdk"
             ],
-            "time": "2017-06-26 19:59:19"
+            "time": "2017-06-26T19:59:19+00:00"
         },
         {
             "name": "facebook/facebook-instant-articles-sdk-php",
-            "version": "v1.6.2",
+            "version": "v1.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/facebook-instant-articles-sdk-php.git",
-                "reference": "f18461923e17af6f05120c687c9f20a540f3d420"
+                "reference": "d2ccefa4da393ea33b9c095a7ebce7b352e31480"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/facebook-instant-articles-sdk-php/zipball/f18461923e17af6f05120c687c9f20a540f3d420",
-                "reference": "f18461923e17af6f05120c687c9f20a540f3d420",
+                "url": "https://api.github.com/repos/facebook/facebook-instant-articles-sdk-php/zipball/d2ccefa4da393ea33b9c095a7ebce7b352e31480",
+                "reference": "d2ccefa4da393ea33b9c095a7ebce7b352e31480",
                 "shasum": ""
             },
             "require": {
-                "apache/log4php": "2.3.0",
                 "facebook/graph-sdk": "~5.0",
                 "php": "^5.4 || ^7.0",
-                "symfony/css-selector": "2.8.* || ^3.0"
+                "symfony/css-selector": "^2.8 || ^3.0"
             },
             "require-dev": {
                 "fzaninotto/faker": "^1.6.0",
-                "phpunit/phpunit": "^4.8",
-                "squizlabs/php_codesniffer": "^2.6.0"
+                "phpdocumentor/reflection-docblock": "^2.0",
+                "phpunit/phpunit": "4.8.*",
+                "squizlabs/php_codesniffer": "^2.6.0",
+                "symfony/yaml": "2.1.*"
             },
             "type": "library",
             "autoload": {
@@ -136,7 +136,7 @@
                 "instant",
                 "sdk"
             ],
-            "time": "2017-07-27 19:19:51"
+            "time": "2018-03-16T19:42:33+00:00"
         },
         {
             "name": "facebook/graph-sdk",
@@ -194,20 +194,20 @@
                 "facebook",
                 "sdk"
             ],
-            "time": "2018-02-14 23:24:51"
+            "time": "2018-02-14T23:24:51+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.8.25",
+            "version": "v2.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "ba3204654efa779691fac9e948a96b4a7067e4ab"
+                "reference": "99a4b2c2f1757d62d081b5f9f14128f23504897d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ba3204654efa779691fac9e948a96b4a7067e4ab",
-                "reference": "ba3204654efa779691fac9e948a96b4a7067e4ab",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/99a4b2c2f1757d62d081b5f9f14128f23504897d",
+                "reference": "99a4b2c2f1757d62d081b5f9f14128f23504897d",
                 "shasum": ""
             },
             "require": {
@@ -247,69 +247,42 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-01 14:31:55"
+            "time": "2018-02-03T14:55:47+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -327,27 +300,28 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22 02:43:20"
+            "time": "2018-02-20T21:35:23+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.12.0",
+            "version": "0.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "300c15796584d6b63f31841daf674886303af573"
+                "reference": "cf6b310caad735816caef7573295f8a534374706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/300c15796584d6b63f31841daf674886303af573",
-                "reference": "300c15796584d6b63f31841daf674886303af573",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
+                "reference": "cf6b310caad735816caef7573295f8a534374706",
                 "shasum": ""
             },
             "require": {
-                "squizlabs/php_codesniffer": "^2.9.0"
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "*"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -366,7 +340,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-07-20 20:11:03"
+            "time": "2018-02-16T01:57:48+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6a2cc31f65a3b6fe00400e4da6e1ef5f",
-    "content-hash": "eaee25ff0d1638dc2a061e4bd67a9f47",
+    "hash": "9ced014a825a211201d9e61e62b4261b",
+    "content-hash": "2c9df27aa7672a2e915ebf6e6f7c513b",
     "packages": [
         {
             "name": "apache/log4php",
@@ -140,16 +140,16 @@
         },
         {
             "name": "facebook/graph-sdk",
-            "version": "5.6.0",
+            "version": "5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-graph-sdk.git",
-                "reference": "34f5e5993c67acd264017373f23848961585dcac"
+                "reference": "030f8c5b9b1a6c09e71719fd638b66ea4daa2f10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/34f5e5993c67acd264017373f23848961585dcac",
-                "reference": "34f5e5993c67acd264017373f23848961585dcac",
+                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/030f8c5b9b1a6c09e71719fd638b66ea4daa2f10",
+                "reference": "030f8c5b9b1a6c09e71719fd638b66ea4daa2f10",
                 "shasum": ""
             },
             "require": {
@@ -194,7 +194,7 @@
                 "facebook",
                 "sdk"
             ],
-            "time": "2017-07-23 14:06:52"
+            "time": "2018-02-14 23:24:51"
         },
         {
             "name": "symfony/css-selector",

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -491,7 +491,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 				$graph_api_call = add_query_arg( 'scrape', 'true', $graph_api_call);
 
 				try {
-					$fb->post( $graph_api_call, null, $access_token );
+					$fb->post( $graph_api_call, [], $access_token );
 					add_action( 'admin_notices', 'admin_notice__scrape_invalidation_success' );
 
 				} catch(Facebook\Exceptions\FacebookResponseException $e) {
@@ -500,7 +500,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 
 					add_action( 'admin_notices', 'admin_notice__scrape_invalidation_failed' );
 				} catch(Facebook\Exceptions\FacebookSDKException $e) {
-					
+
 					add_action( 'admin_notices', 'admin_notice__scrape_invalidation_failed' );
 				}
 			}

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -439,4 +439,73 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	}
 	add_action( 'updated_option', 'invalidate_all_posts_transformation_info_cache', 10, 1 );
 
+	function invalidate_scrape_on_update( $post_ID, $post_after, $post_before ) {
+		$adapter = new Instant_Articles_Post( $post_after );
+		if ( $adapter->should_submit_post() ) {
+			$fb_app_settings = Instant_Articles_Option_FB_App::get_option_decoded();
+			if (
+				( isset( $fb_app_settings[ 'page_access_token' ] ) && $fb_app_settings[ 'page_access_token' ] ) &&
+				( isset( $fb_app_settings[ 'app_id' ] ) && $fb_app_settings[ 'app_id' ] ) &&
+				( isset( $fb_app_settings[ 'app_secret' ] ) && $fb_app_settings[ 'app_secret' ] )
+			) {
+				// Fetches the right URL to invalidate
+				$url = $adapter->get_canonical_url();
+
+				// oAuth info
+				$app_id = $fb_app_settings[ 'app_id' ];
+				$app_secret = $fb_app_settings[ 'app_secret' ];
+				$access_token = $fb_app_settings[ 'page_access_token' ];
+
+				// Build Graph SDK instance
+				$fb = new \Facebook\Facebook([
+					'app_id' => $app_id,
+					'app_secret' => $app_secret,
+					'default_access_token' => $access_token
+				]);
+
+				function admin_notice__scrape_invalidation_failed() {
+					?>
+					<div class="notice notice-error is-dismissible">
+						<p>
+							<?php _e( 'It was not possible to automatically invalidate the scrape for this article.', IA_PLUGIN_TEXT_DOMAIN ) ?>
+							<?php _e( 'Please trigger a new scrape manually using the Facebook Share Debugger.', IA_PLUGIN_TEXT_DOMAIN ) ?>
+						</p>
+					</div>
+					<?php
+				}
+
+				function admin_notice__scrape_invalidation_success() {
+					?>
+					<div class="notice notice-success is-dismissible">
+						<p>
+							<?php _e( 'Successfully refreshed the Instant Articles cache for this article.', IA_PLUGIN_TEXT_DOMAIN ) ?>
+						</p>
+					</div>
+					<?php
+				}
+
+
+				// Make call
+				$graph_api_call = '/';
+				$graph_api_call = add_query_arg( 'id', rawurlencode($url), $graph_api_call);
+				$graph_api_call = add_query_arg( 'scrape', 'true', $graph_api_call);
+
+				try {
+					$fb->post( $graph_api_call, null, $access_token );
+					add_action( 'admin_notices', 'admin_notice__scrape_invalidation_success' );
+
+				} catch(Facebook\Exceptions\FacebookResponseException $e) {
+					echo '<pre>';
+					print_r($e->getTraceAsString());
+
+					add_action( 'admin_notices', 'admin_notice__scrape_invalidation_failed' );
+				} catch(Facebook\Exceptions\FacebookSDKException $e) {
+					
+					add_action( 'admin_notices', 'admin_notice__scrape_invalidation_failed' );
+				}
+			}
+		}
+	}
+	add_action( 'post_updated', 'invalidate_scrape_on_update', 10, 3 );
+
 }

--- a/wizard/class-instant-articles-option-fb-app.php
+++ b/wizard/class-instant-articles-option-fb-app.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option.php' );
+
+/**
+ * FB Page configuration.
+ */
+class Instant_Articles_Option_FB_App extends Instant_Articles_Option {
+
+	const OPTION_KEY = 'instant-articles-option-fb-app';
+
+	public static $sections = array(
+		'title' => 'Facebook App',
+		'description' => '<p>Configure your Facebook App to enable auto-invalidation of the cache when updating articles</p>',
+	);
+
+	public static $fields = array(
+		'app_id' => array(
+			'visible' => true,
+			'label' => 'Facebook App ID',
+			'default' => '',
+			'description' => 'Provide a valid App ID',
+		),
+		'app_secret' => array(
+			'visible' => true,
+			'label' => 'Facebook App Secret',
+			'default' => '',
+			'description' => 'Provide a valid App Secret',
+		),
+
+		'page_access_token' => array(
+			'visible' => true,
+			'label' => 'Page Access Token',
+			'default' => '',
+			'description' => 'Provide a valid access token for your Page',
+		),
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.4
+	 */
+	public function __construct() {
+		$this->options_manager = new parent(
+			self::OPTION_KEY,
+			self::$sections,
+			self::$fields
+		);
+	}
+}

--- a/wizard/class-instant-articles-wizard.php
+++ b/wizard/class-instant-articles-wizard.php
@@ -9,6 +9,7 @@
 require_once( dirname( __FILE__ ) . '/class-instant-articles-option-ads.php' );
 require_once( dirname( __FILE__ ) . '/class-instant-articles-option-analytics.php' );
 require_once( dirname( __FILE__ ) . '/class-instant-articles-option-fb-page.php' );
+require_once( dirname( __FILE__ ) . '/class-instant-articles-option-fb-app.php' );
 require_once( dirname( __FILE__ ) . '/class-instant-articles-option-publishing.php' );
 require_once( dirname( __FILE__ ) . '/class-instant-articles-option-styles.php' );
 require_once( dirname( __FILE__ ) . '/class-instant-articles-option-amp.php' );
@@ -31,6 +32,7 @@ class Instant_Articles_Wizard {
 
 		add_action( 'admin_init', function () {
 			new Instant_Articles_Option_FB_Page();
+			new Instant_Articles_Option_FB_App();
 			new Instant_Articles_Option_Styles();
 			new Instant_Articles_Option_Ads();
 			new Instant_Articles_Option_Analytics();

--- a/wizard/templates/advanced-template.php
+++ b/wizard/templates/advanced-template.php
@@ -23,6 +23,8 @@
 						<?php $fb_page_settings = Instant_Articles_Option_FB_Page::get_option_decoded(); ?>
 						<div <?php if ( isset( $fb_page_settings[ 'page_id' ] ) && ! $fb_page_settings[ 'page_id' ] ) : ?>style="display: none;"<?php endif; ?>>
 							<hr />
+							<?php do_settings_sections( Instant_Articles_Option_FB_App::OPTION_KEY ); ?>
+							<hr />
 							<p>Configure settings for your styles, ads, analytics and publishing in Instant Articles. Review our <a href="https://developers.facebook.com/docs/instant-articles" target="_blank">developer documentation</a> to learn more.</p>
 							<hr />
 							<?php do_settings_sections( Instant_Articles_Option_Styles::OPTION_KEY ); ?>


### PR DESCRIPTION
This PR:

* [x] Creates a configuration settings where you can inform `App ID`, `App secret` and `Access Token`
* [x] Calls re-scrape with the App settings if well set
* [x] Treats errors on configuration and properly shows error message if not successful rescraped

Fixes #878
