### PR TITLE
Add PassThroughRule for Grammarly

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -365,6 +365,9 @@
                 "selector" : "figcaption.wp-caption-text"
             }
         }
+    }, {
+      "class": "PassThroughRule",
+      "selector": "g"
     }
   ]
 }

--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -24,6 +24,9 @@
         "class": "PassThroughRule",
         "selector" : "span"
     }, {
+      "class": "PassThroughRule",
+      "selector": "g"
+    }, {
         "class": "ParagraphRule",
         "selector": "p"
     }, {
@@ -365,9 +368,6 @@
                 "selector" : "figcaption.wp-caption-text"
             }
         }
-    }, {
-      "class": "PassThroughRule",
-      "selector": "g"
     }
   ]
 }


### PR DESCRIPTION
This PR:

* [x] Adds PassThroughRule for tag `<g>` which is used by Grammarly

Whenever Grammarly makes a correction in text, it wraps the text with `<g>` tags like this:

```html
<g class="gr_ gr_8 gr-alert gr_gramm gr_inline_cards gr_run_anim Grammar only-ins replaceWithoutSep" id="8" data-gr-id="8">Because</g>
```

This PR adds a PassThroughRule for the `g` selector.

See also: https://github.com/tinymce/tinymce/issues/3625#issuecomment-299881345