### PR TITLE
Add token-less re-scrape with request signature

### DIFF
--- a/class-instant-articles-signer.php
+++ b/class-instant-articles-signer.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Facebook Instant Articles for WP.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package default
+ */
+
+/**
+ * Class responsible for handling the signature of graph rescrape calls
+ *
+ * @since 4.1
+ */
+class Instant_Articles_Signer {
+
+  const PUBLIC_KEY_OPTION = 'instant-articles-rescrape-public-key';
+  const PRIVATE_KEY_OPTION = 'instant-articles-rescrape-private-key';
+  const PUBLIC_KEY_PATH = '/.well-known/graph-api/apikey.pub';
+
+  public static function init() {
+    add_action( 'wp', array( 'Instant_Articles_Signer', 'output_public_key' ) );
+  }
+
+  public static function output_public_key() {
+    global $wp;
+    if ( $wp->request == self::PUBLIC_KEY_PATH ) {
+      echo self::get_public_key();
+      die();
+    }
+  }
+
+  public static function get_public_key() {
+    $public_key = get_option( self::PUBLIC_KEY_OPTION );
+    if ( ! $public_key ) {
+      self::gen_keys();
+      $public_key = get_option( self::PUBLIC_KEY_OPTION );
+    }
+    return $public_key;
+  }
+
+  public static function get_private_key() {
+    $private_key = get_option( self::PRIVATE_KEY_OPTION );
+    if ( ! $private_key ) {
+      self::gen_keys();
+      $private_key = get_option( self::PRIVATE_KEY_OPTION );
+    }
+    return $private_key;
+  }
+
+  private static function gen_keys( $force = false ) {
+    $public_key = get_option( self::PUBLIC_KEY_OPTION );
+    $private_key = get_option( self::PRIVATE_KEY_OPTION );
+
+    if ( !$force && $private_key && $public_key ) {
+      return;
+    }
+
+    // Create the private and public key
+    $result = openssl_pkey_new();
+
+    // Extract the private key from $result to $private_key
+    openssl_pkey_export( $result, $private_key );
+
+    // Extract the public key from $result to $public_key
+    $public_key = openssl_pkey_get_details( $result );
+    $public_key = $public_key["key"];
+
+    update_option( self::PRIVATE_KEY_OPTION, $private_key );
+    update_option( self::PUBLIC_KEY_OPTION, $public_key );
+  }
+
+  public static function get_signature( $data ) {
+    openssl_private_sign( $data, $signature, self::get_private_key() );
+    return $signature;
+  }
+
+  public static function sign_request_path( $path ) {
+    $now = new DateTime();
+    $ts = $now->getTimestamp();
+    $path = add_query_arg( 'ts', $ts, $path );
+    $signature = self::get_signature( $path );
+    $path = add_query_arg( 'signature', $signature, $path );
+    return $path;
+  }
+
+}

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -569,8 +569,6 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 		$adapter = new Instant_Articles_Post( $post );
 		$old_slugs = get_post_meta( $post_id, '_wp_old_slug' );
 		if ( $adapter->should_submit_post() ) {
-
-
 			$fb_app_settings = Instant_Articles_Option_FB_App::get_option_decoded();
 			if (
 				( isset( $fb_app_settings[ 'page_access_token' ] ) && $fb_app_settings[ 'page_access_token' ] ) &&

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -582,23 +582,9 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 			}
 
 			try {
-				$client = Facebook\HttpClients\HttpClientsFactory::createHttpClient( null );
-				$url_encoded = urlencode($adapter->get_canonical_url());
-				$client->send(
-					Instant_Articles_Signer::sign_request_path(
-						"https://graph.facebook.com/?id=$url_encoded&scrape=true"
-					),
-					'POST',
-					'',
-					array(),
-					60
-				);
-				foreach ( $old_slugs as $slug ) {
-					$clone_post = clone $post;
-					$clone_post->post_name = $slug;
-					$clone_adapter = new Instant_Articles_Post( $clone_post );
-
-					$url_encoded = urlencode($clone_adapter->get_canonical_url());
+				if ( extension_loaded('openssl') ) {
+					$client = Facebook\HttpClients\HttpClientsFactory::createHttpClient( null );
+					$url_encoded = urlencode($adapter->get_canonical_url());
 					$client->send(
 						Instant_Articles_Signer::sign_request_path(
 							"https://graph.facebook.com/?id=$url_encoded&scrape=true"
@@ -608,6 +594,22 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 						array(),
 						60
 					);
+					foreach ( $old_slugs as $slug ) {
+						$clone_post = clone $post;
+						$clone_post->post_name = $slug;
+						$clone_adapter = new Instant_Articles_Post( $clone_post );
+
+						$url_encoded = urlencode($clone_adapter->get_canonical_url());
+						$client->send(
+							Instant_Articles_Signer::sign_request_path(
+								"https://graph.facebook.com/?id=$url_encoded&scrape=true"
+							),
+							'POST',
+							'',
+							array(),
+							60
+						);
+					}
 				}
 			} catch ( Exception $e ) {
 				Logger::getLogger( 'instantarticles-wp-plugin' )->error(

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -427,6 +427,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	add_action( 'wp', array('Instant_Articles_AMP_Markup', 'markup_version') );
 
 	Instant_Articles_Wizard::init();
+	Instant_Articles_Signer::init();
 
 	function invalidate_post_transformation_info_cache( $post_id, $post ) {
 		// These post metas are caches on the calculations made to decide if
@@ -562,5 +563,61 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 		}
 	}
 	add_action( 'post_updated', 'invalidate_scrape_on_update', 10, 3 );
+
+	function rescrape_article( $post_id, $post ) {
+		$adapter = new Instant_Articles_Post( $post );
+		$old_slugs = get_post_meta( $post_id, '_wp_old_slug' );
+		if ( $adapter->should_submit_post() ) {
+
+
+			$fb_app_settings = Instant_Articles_Option_FB_App::get_option_decoded();
+			if (
+				( isset( $fb_app_settings[ 'page_access_token' ] ) && $fb_app_settings[ 'page_access_token' ] ) &&
+				( isset( $fb_app_settings[ 'app_id' ] ) && $fb_app_settings[ 'app_id' ] ) &&
+				( isset( $fb_app_settings[ 'app_secret' ] ) && $fb_app_settings[ 'app_secret' ] )
+			) {
+				// Defer to access_token if configured to ensure backwards compatibility
+				return;
+			}
+
+			try {
+				$client = Facebook\HttpClients\HttpClientsFactory::createHttpClient( null );
+				$url_encoded = urlencode($adapter->get_canonical_url());
+				$client->send(
+					'https://graph.facebook.com' .
+					Instant_Articles_Signer::sign_request_path(
+						"/?id=$url_encoded&scrape=true",
+					),
+					'POST',
+					'',
+					array(),
+					60
+				);
+				foreach ( $old_slugs as $slug ) {
+					$clone_post = clone $post;
+					$clone_post->post_name = $slug;
+					$clone_adapter = new Instant_Articles_Post( $clone_post );
+
+					$url_encoded = urlencode($clone_adapter->get_canonical_url());
+					$client->send(
+						'https://graph.facebook.com' .
+						Instant_Articles_Signer::sign_request_path(
+							"/?id=$url_encoded&scrape=true",
+						),
+						'POST',
+						'',
+						array(),
+						60
+					);
+				}
+			} catch ( Exception $e ) {
+				Logger::getLogger( 'instantarticles-wp-plugin' )->error(
+					'Unable to submit article.',
+					$e->getTraceAsString()
+				);
+			}
+		}
+	}
+	add_action( 'save_post', 'rescrape_article', 999, 2 );
 
 }

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -85,6 +85,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	require_once( dirname( __FILE__ ) . '/wizard/class-instant-articles-wizard.php' );
 	require_once( dirname( __FILE__ ) . '/meta-box/class-instant-articles-meta-box.php' );
 	require_once( dirname( __FILE__ ) . '/class-instant-articles-amp-markup.php' );
+	require_once( dirname( __FILE__ ) . '/class-instant-articles-signer.php' );
 
 	/**
 	 * Plugin activation hook to add our rewrite rules.
@@ -584,9 +585,8 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 				$client = Facebook\HttpClients\HttpClientsFactory::createHttpClient( null );
 				$url_encoded = urlencode($adapter->get_canonical_url());
 				$client->send(
-					'https://graph.facebook.com' .
 					Instant_Articles_Signer::sign_request_path(
-						"/?id=$url_encoded&scrape=true",
+						"https://graph.facebook.com/?id=$url_encoded&scrape=true"
 					),
 					'POST',
 					'',
@@ -600,9 +600,8 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 
 					$url_encoded = urlencode($clone_adapter->get_canonical_url());
 					$client->send(
-						'https://graph.facebook.com' .
 						Instant_Articles_Signer::sign_request_path(
-							"/?id=$url_encoded&scrape=true",
+							"https://graph.facebook.com/?id=$url_encoded&scrape=true"
 						),
 						'POST',
 						'',


### PR DESCRIPTION
This PR aims to do trigger a token-less re-scrape of the URLs being updated to trigger a new Instant Article ingestion even if the user does not have a configured app ID/app secret/access token.

- [x] Create key generation/exposure logic
- [x] Gracefully degrade to require a token when OpenSSL lib is not available