### PR TITLE
Add support for GTM4WP

### DIFF
--- a/compat.php
+++ b/compat.php
@@ -28,6 +28,13 @@ if ( ( defined( 'GAWP_VERSION' ) || function_exists( 'MonsterInsights' ) ) && ! 
 	$gawp->init();
 }
 
+// Load support for Google Tag Manager for WordPress by Duracelltomi.
+if ( defined( 'GTM4WP_VERSION' ) && function_exists( 'gtm4wp_wp_header_begin' ) ) {
+  include( dirname( __FILE__ ) . '/compat/class-instant-articles-gtm4wp.php' );
+  $gtm4wp = new Instant_Articles_Google_Tag_Manager_For_WordPress;
+  $gtm4wp->init();
+}
+
 // Load support for Jetpack
 if ( defined( 'JETPACK__VERSION' ) ) {
 	include( dirname( __FILE__ ) . '/compat/class-instant-articles-jetpack.php' );

--- a/compat.php
+++ b/compat.php
@@ -29,7 +29,7 @@ if ( ( defined( 'GAWP_VERSION' ) || function_exists( 'MonsterInsights' ) ) && ! 
 }
 
 // Load support for Google Tag Manager for WordPress by Duracelltomi.
-if ( defined( 'GTM4WP_VERSION' ) && function_exists( 'gtm4wp_wp_header_begin' ) ) {
+if ( defined( 'GTM4WP_VERSION' ) ) {
   include( dirname( __FILE__ ) . '/compat/class-instant-articles-gtm4wp.php' );
   $gtm4wp = new Instant_Articles_Google_Tag_Manager_For_WordPress;
   $gtm4wp->init();

--- a/compat/class-instant-articles-gtm4wp.php
+++ b/compat/class-instant-articles-gtm4wp.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Support class for Google Tag Manager for WordPress by DuracellTomi
+ *
+ * @since 4.0.7
+ */
+class Instant_Articles_Google_Tag_Manager_For_WordPress {
+
+  /**
+   * Init the compat layer and add the instantArticle variable to the GTM4WP dataLayer.
+   */
+  function init() {
+    add_action( 'instant_articles_compat_registry_analytics', array( $this, 'add_to_registry' ), 10, 1 );
+    add_filter( 'gtm4wp_compile_datalayer', array( $this, 'add_ia_status_to_data_layer' ), 10, 1 );
+  }
+  /**
+   * Adds identifying information about this 3rd party plugin
+   * to the wider registry.
+   *
+   * @since 4.0.7
+   * @param array $registry Reference param. The registry where it will be stored.
+   */
+  function add_to_registry( &$registry ) {
+    $display_name = 'Google Tag Manager by DuracellTomi (will also add an instantArticle variable to dataLayer)';
+    $identifier = 'duracelltomi-google-tag-manager';
+    $registry[ $identifier ] = array(
+      'name' => $display_name,
+      'payload' => gtm4wp_wp_header_begin(false),
+    );
+  }
+
+  function add_ia_status_to_data_layer($dataLayer) {
+    $dataLayer["instantArticle"] = \is_transforming_instant_article();
+
+    return $dataLayer;
+  }
+}

--- a/compat/class-instant-articles-gtm4wp.php
+++ b/compat/class-instant-articles-gtm4wp.php
@@ -21,6 +21,10 @@ class Instant_Articles_Google_Tag_Manager_For_WordPress {
    * @param array $registry Reference param. The registry where it will be stored.
    */
   function add_to_registry( &$registry ) {
+    if ( !function_exists( 'gtm4wp_wp_header_begin' ) ) {
+      include_once( WP_PLUGIN_DIR . '/duracelltomi-google-tag-manager/public/frontend.php' );
+    }
+
     $display_name = 'Google Tag Manager by DuracellTomi (will also add an instantArticle variable to dataLayer)';
     $identifier = 'duracelltomi-google-tag-manager';
     $registry[ $identifier ] = array(


### PR DESCRIPTION
This PR:

* [x] Adds support for [Google Tag Manager for WordPress by Duracelltomi (GTM4WP)](https://gtm4wp.com/)
