### PR TITLE
Fix incomplete implementation of GTM4WP

### DIFF
--- a/compat/class-instant-articles-gtm4wp.php
+++ b/compat/class-instant-articles-gtm4wp.php
@@ -21,7 +21,7 @@ class Instant_Articles_Google_Tag_Manager_For_WordPress {
    * @param array $registry Reference param. The registry where it will be stored.
    */
   function add_to_registry( &$registry ) {
-    if ( !function_exists( 'gtm4wp_wp_header_begin' ) ) {
+    if ( !function_exists( 'gtm4wp_wp_header_begin' ) || !function_exists( 'gtm4wp_wp_header_top' ) ) {
       include_once( WP_PLUGIN_DIR . '/duracelltomi-google-tag-manager/public/frontend.php' );
     }
 
@@ -29,7 +29,7 @@ class Instant_Articles_Google_Tag_Manager_For_WordPress {
     $identifier = 'duracelltomi-google-tag-manager';
     $registry[ $identifier ] = array(
       'name' => $display_name,
-      'payload' => gtm4wp_wp_header_begin(false),
+      'payload' => gtm4wp_wp_header_top(false).gtm4wp_wp_header_begin(false),
     );
   }
 


### PR DESCRIPTION
So while everything appeared to be working fine after implementing #941, it turns out its not. If FB still had better debugging tools around, I would've caught this sooner, sadly it took us missing a few weeks of Google Analytics data before I did. At least it didn't get released publicly yet!

This depends on https://github.com/duracelltomi/gtm4wp/pull/81 being merged.