### PR TITLE
Delete current transient with autoload=yes.

### DIFF
--- a/embeds.php
+++ b/embeds.php
@@ -68,7 +68,7 @@ function instant_articles_embed_oembed_html( $html, $url, $attr, $post_id ) {
 
 	if ( $provider_name ) {
 		$html = instant_articles_embed_get_html( $provider_name, $html, $url, $attr, $post_id );
-    delete_transient( $cache_key );
+		delete_transient( $cache_key );
 	}
 
 	return $html;

--- a/embeds.php
+++ b/embeds.php
@@ -68,6 +68,7 @@ function instant_articles_embed_oembed_html( $html, $url, $attr, $post_id ) {
 
 	if ( $provider_name ) {
 		$html = instant_articles_embed_get_html( $provider_name, $html, $url, $attr, $post_id );
+    delete_transient( $cache_key );
 	}
 
 	return $html;


### PR DESCRIPTION
This PR:

Delete transient when create on autoload=yes, which is overloading the mysql response, which needs to return a huge amount of completely unnecessary information.

Follows #

Relates to # Issue: https://github.com/Automattic/facebook-instant-articles-wp/issues/901#issuecomment-396352556

Fixes # Delete transient when create on autoload=yes
