### PR TITLE
Removed fields from deprecated feature to enable comments/likes/share from media content

### DIFF
--- a/class-instant-articles-post.php
+++ b/class-instant-articles-post.php
@@ -681,19 +681,6 @@ class Instant_Articles_Post {
 
 		$this->set_appearance_from_settings();
 
-		// This block sets as default likes and/or comments based on the configuration setup,
-		// and call $transformer->transform will consider the defaults before building the Elements
-		//
-		// Warning: if you are using pthreads or any other multithreaded engine, consider replicating this to all processes.
-		if ( isset( $settings_publishing[ 'likes_on_media' ] ) ) {
-			Image::setDefaultLikeEnabled( $settings_publishing[ 'likes_on_media' ] );
-			Video::setDefaultLikeEnabled( $settings_publishing[ 'likes_on_media' ] );
-		}
-		if ( isset( $settings_publishing[ 'comments_on_media' ] ) ) {
-			Image::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
-			Video::setDefaultCommentEnabled( $settings_publishing[ 'comments_on_media' ] );
-		}
-
 		$the_content = $this->get_the_content();
 		if (!Type::isTextEmpty($the_content)) {
 			$transformer->transformString( $this->instant_article, $the_content, get_option( 'blog_charset' ) );

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
   "require":
   {
     "php": ">=5.4",
-    "apache/log4php": "2.3.0",
     "facebook/facebook-instant-articles-sdk-php": "^1.9.0",
     "facebook/facebook-instant-articles-sdk-extensions-in-php": "^0.1.0",
     "symfony/css-selector": "2.8.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1,41 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01d0240e7e9964e8190765878d7e96e9",
+    "content-hash": "6fc7e564f10f2fb780945fa88bfc9210",
     "packages": [
-        {
-            "name": "apache/log4php",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://git-wip-us.apache.org/repos/asf/logging-log4php.git",
-                "reference": "cac428b6f67d2035af39784da1d1a299ef42fcf2"
-            },
-            "require": {
-                "php": ">=5.2.7"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/main/php/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "A versatile logging framework for PHP",
-            "homepage": "http://logging.apache.org/log4php/",
-            "keywords": [
-                "log",
-                "logging",
-                "php"
-            ],
-            "time": "2012-10-26T09:13:25+00:00"
-        },
         {
             "name": "facebook/facebook-instant-articles-sdk-extensions-in-php",
             "version": "v0.1.1",
@@ -88,22 +58,22 @@
         },
         {
             "name": "facebook/facebook-instant-articles-sdk-php",
-            "version": "v1.9.2",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/facebook-instant-articles-sdk-php.git",
-                "reference": "d2ccefa4da393ea33b9c095a7ebce7b352e31480"
+                "reference": "ddd592500bd377af1965602fc008e6f593e63532"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/facebook-instant-articles-sdk-php/zipball/d2ccefa4da393ea33b9c095a7ebce7b352e31480",
-                "reference": "d2ccefa4da393ea33b9c095a7ebce7b352e31480",
+                "url": "https://api.github.com/repos/facebook/facebook-instant-articles-sdk-php/zipball/ddd592500bd377af1965602fc008e6f593e63532",
+                "reference": "ddd592500bd377af1965602fc008e6f593e63532",
                 "shasum": ""
             },
             "require": {
                 "facebook/graph-sdk": "~5.0",
-                "php": "^5.4 || ^7.0",
-                "symfony/css-selector": "^2.8 || ^3.0"
+                "php": "^5.4 || ^5.6 || ^7",
+                "symfony/css-selector": "^2.8 || ^3.1 || ^4.1"
             },
             "require-dev": {
                 "fzaninotto/faker": "^1.6.0",
@@ -136,20 +106,20 @@
                 "instant",
                 "sdk"
             ],
-            "time": "2018-03-16T19:42:33+00:00"
+            "time": "2018-11-29T14:50:41+00:00"
         },
         {
             "name": "facebook/graph-sdk",
-            "version": "5.6.2",
+            "version": "5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-graph-sdk.git",
-                "reference": "030f8c5b9b1a6c09e71719fd638b66ea4daa2f10"
+                "reference": "90e92bd1816fe718e55184ab85910dfcf488432c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/030f8c5b9b1a6c09e71719fd638b66ea4daa2f10",
-                "reference": "030f8c5b9b1a6c09e71719fd638b66ea4daa2f10",
+                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/90e92bd1816fe718e55184ab85910dfcf488432c",
+                "reference": "90e92bd1816fe718e55184ab85910dfcf488432c",
                 "shasum": ""
             },
             "require": {
@@ -194,20 +164,20 @@
                 "facebook",
                 "sdk"
             ],
-            "time": "2018-02-14T23:24:51+00:00"
+            "time": "2018-07-03T02:25:00+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.8.36",
+            "version": "v2.8.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "99a4b2c2f1757d62d081b5f9f14128f23504897d"
+                "reference": "7b1692e418d7ccac24c373528453bc90e42797de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/99a4b2c2f1757d62d081b5f9f14128f23504897d",
-                "reference": "99a4b2c2f1757d62d081b5f9f14128f23504897d",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/7b1692e418d7ccac24c373528453bc90e42797de",
+                "reference": "7b1692e418d7ccac24c373528453bc90e42797de",
                 "shasum": ""
             },
             "require": {
@@ -247,22 +217,22 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-03T14:55:47+00:00"
+            "time": "2018-11-11T11:18:13+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.3",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
                 "shasum": ""
             },
             "require": {
@@ -300,28 +270,31 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-02-20T21:35:23+00:00"
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "cf6b310caad735816caef7573295f8a534374706"
+                "reference": "7aa217ab38156c5cb4eae0f04ae376027c407a9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
-                "reference": "cf6b310caad735816caef7573295f8a534374706",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/7aa217ab38156c5cb4eae0f04ae376027c407a9b",
+                "reference": "7aa217ab38156c5cb4eae0f04ae376027c407a9b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -340,7 +313,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-02-16T01:57:48+00:00"
+            "time": "2018-11-12T10:13:12+00:00"
         }
     ],
     "aliases": [],

--- a/facebook-instant-articles.php
+++ b/facebook-instant-articles.php
@@ -33,39 +33,6 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	$autoloader->add( 'Facebook\\', __DIR__ . '/vendor/facebook/facebook-instant-articles-sdk-php/src' );
 	$autoloader->add( 'Facebook\\', __DIR__ . '/vendor/facebook/facebook-instant-articles-sdk-extensions-in-php/src' );
 
-	// Configures log to go through console.
-	\Logger::configure(
-		array(
-			'rootLogger' => array(
-				'appenders' => array( 'facebook-instantarticles-transformer' ),
-			),
-			'appenders' => array(
-				'facebook-instantarticles-transformer' => array(
-					'class' => 'LoggerAppenderConsole',
-					'threshold' => 'INFO',
-					'layout' => array(
-						'class' => 'LoggerLayoutSimple',
-					),
-				),
-				'facebook-instantarticles-client' => array(
-					'class' => 'LoggerAppenderConsole',
-					'threshold' => 'INFO',
-					'layout' => array(
-						'class' => 'LoggerLayoutSimple',
-					),
-				),
-				'instantarticles-wp-plugin' => array(
-					'class' => 'LoggerAppenderConsole',
-					'threshold' => 'INFO',
-					'layout' => array(
-						'class' => 'LoggerLayoutSimple',
-					),
-				),
-			),
-		)
-	);
-
-
 	defined( 'ABSPATH' ) || die( 'Shame on you' );
 
 	define( 'IA_PLUGIN_VERSION', '4.1.1' );
@@ -610,10 +577,7 @@ if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
 					}
 				}
 			} catch ( Exception $e ) {
-				Logger::getLogger( 'instantarticles-wp-plugin' )->error(
-					'Unable to submit article.',
-					$e->getTraceAsString()
-				);
+				error_log( 'Unable to submit article.'.$e->getTraceAsString()	);
 			}
 		}
 	}

--- a/tests/Facebook/InstantArticles/Transformer/WPTransformerTest.php
+++ b/tests/Facebook/InstantArticles/Transformer/WPTransformerTest.php
@@ -16,26 +16,6 @@ use Facebook\InstantArticles\Elements\Author;
 
 class WPTransformerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        \Logger::configure(
-            [
-                'rootLogger' => [
-                    'appenders' => ['facebook-instantarticles-transformer']
-                ],
-                'appenders' => [
-                    'facebook-instantarticles-transformer' => [
-                        'class' => 'LoggerAppenderConsole',
-                        'threshold' => 'INFO',
-                        'layout' => [
-                            'class' => 'LoggerLayoutSimple'
-                        ]
-                    ]
-                ]
-            ]
-        );
-    }
-
     public function testTransformerLikeWPContent()
     {
         $json_file = file_get_contents(__DIR__ . '/wp-rules.json');

--- a/wizard/class-instant-articles-option-publishing.php
+++ b/wizard/class-instant-articles-option-publishing.php
@@ -61,22 +61,6 @@ class Instant_Articles_Option_Publishing extends Instant_Articles_Option {
 			'render' => 'checkbox',
 			'default' => false,
 			'checkbox_label' => 'Enable column "FB IA Status"',
-		),
-
-		'likes_on_media' => array(
-			'label' => 'Likes',
-			'description' => 'With this option enabled, any image or video will have the like action enabled by default.',
-			'render' => 'checkbox',
-			'default' => false,
-			'checkbox_label' => 'Enable like action on images and videos by default',
-		),
-
-		'comments_on_media' => array(
-			'label' => 'Comments',
-			'description' => 'With this option enabled, any image or video will have the comments enabled by default.',
-			'render' => 'checkbox',
-			'default' => false,
-			'checkbox_label' => 'Enable comments on images and videos by default',
 		)
 
 	);


### PR DESCRIPTION
This adapts the Instant Articles Wordpress plugin to adapt to the deprecation of media feedback to individual media components of Instant Articles.

Commonly used attribute into the figure.
```
<figure data-feedback="fb:likes, fb:comments">
  <img src="http://mydomain.com/path/to/img.jpg" />
</figure>
```
This takes no effect and we stopped outputting in case this gets enabled. So the methods enabling/disabling data-feedback are set to do nothing now. 

On the plugin, we removed the setup page for this properties.

Relates to https://github.com/facebook/facebook-instant-articles-sdk-php/pull/347
