### PR TITLE
Update Facebook SDK versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
   "require":
   {
     "php": ">=5.4",
-    "facebook/facebook-instant-articles-sdk-php": "^1.9.0",
-    "facebook/facebook-instant-articles-sdk-extensions-in-php": "^0.1.0",
+    "facebook/facebook-instant-articles-sdk-php": "^1.10.0",
+    "facebook/facebook-instant-articles-sdk-extensions-in-php": "^0.2.1",
     "symfony/css-selector": "2.8.*",
     "facebook/graph-sdk": "^5.6"
   },


### PR DESCRIPTION
Update Facebook Instant Articles SDK to 1.10.0 (from 1.9.0) and Facebook Instant Articles Extensions SDK to 0.2.1 (from 0.1.0).