### PR TITLE
Fix rendering of in-line image, embed and table

### DIFF
--- a/rules-configuration.json
+++ b/rules-configuration.json
@@ -73,24 +73,10 @@
         "selector": "cite"
     }, {
         "class": "ImageRule",
-        "selector": "img",
-        "properties": {
-            "image.url": {
-                "type": "string",
-                "selector": "img",
-                "attribute": "src"
-            }
-        }
+        "selector": "img"
     }, {
         "class": "ImageRule",
-        "selector": "//a[img and not(*[not(self::img)])]",
-        "properties": {
-            "image.url": {
-                "type": "string",
-                "selector": "img",
-                "attribute": "src"
-            }
-        }
+        "selector": "//a[img and not(*[not(self::img)])]"
     }, {
         "class": "ListItemRule",
         "selector" : "li"
@@ -192,11 +178,11 @@
         }
     }, {
         "class": "InteractiveRule",
-        "selector" : "div.embed",
+        "selector" : "figure.wp-block-embed",
         "properties" : {
             "interactive.iframe" : {
                 "type" : "children",
-                "selector" : "div.embed"
+                "selector" : "iframe"
             },
             "interactive.height" : {
                 "type" : "int",
@@ -207,6 +193,11 @@
                 "type" : "int",
                 "selector" : "iframe",
                 "attribute": "width"
+            },
+            "interactive.url" : {
+                "type" : "string",
+                "selector" : "iframe",
+                "attribute": "src"
             }
         }
     }, {
@@ -280,6 +271,25 @@
     }, {
         "class": "InteractiveRule",
         "selector" : "table",
+        "properties" : {
+            "interactive.iframe" : {
+                "type" : "element",
+                "selector" : "table"
+            },
+            "interactive.height" : {
+                "type" : "int",
+                "selector" : "table",
+                "attribute": "height"
+            },
+            "interactive.width" : {
+                "type" : "int",
+                "selector" : "iframe",
+                "attribute": "width"
+            }
+        }
+    }, {
+        "class": "InteractiveRule",
+        "selector" : "figure.wp-block-table",
         "properties" : {
             "interactive.iframe" : {
                 "type" : "element",


### PR DESCRIPTION
Since Gutenberg, WordPress has been using the wp-block-*** class on most of the blocks. So there are lots of unused Interactive Rule that no longer work or exist on the current version of WordPress. For compatibility with older versions, they weren't removed but added and fixed most common issues.

This PR:
Fix and updated rules for
- Embed (YouTube, Vimeo, etc)
- Table 
- In-line images.

Fixes #1052 #1014 #875 
